### PR TITLE
ItemEditTemplate and ItemEditTemplateSelector articles updated to use th...

### DIFF
--- a/controls/radtreeview/populating-with-data/item-edit-template-selector.md
+++ b/controls/radtreeview/populating-with-data/item-edit-template-selector.md
@@ -129,7 +129,7 @@ If you want to read more about __HierarchicalDataTemplate__ and __DataBinding__,
 				<Grid>
 					<StackPanel Orientation="Horizontal">
 						<TextBox Text="{Binding LeagueName, Mode=TwoWay}"/>
-						<telerik:RadMaskedTextBox MaskType="Numeric" Mask="#" Value="{Binding Count, Mode=OneWay}"/>
+						<telerik:RadMaskedNumericInput Mask="#" Value="{Binding Count, Mode=OneWay}"/>
 					</StackPanel>
 				</Grid>
 			</DataTemplate>
@@ -143,7 +143,7 @@ If you want to read more about __HierarchicalDataTemplate__ and __DataBinding__,
 			<DataTemplate x:Key="DivisionItemEditTemplate">
 				<Grid>
 					<StackPanel Orientation="Horizontal">
-						<telerik:RadMaskedTextBox MaskType="Numeric" Mask="#" Value="{Binding Count, Mode=OneWay}"/>
+						<telerik:RadMaskedNumericInput Mask="#" Value="{Binding Count, Mode=OneWay}"/>
 						<TextBox Text="{Binding DivisionName, Mode=TwoWay}"/>
 					</StackPanel>
 				</Grid>
@@ -159,14 +159,14 @@ If you want to read more about __HierarchicalDataTemplate__ and __DataBinding__,
 				<Grid>
 					<StackPanel Orientation="Horizontal">
 						<TextBox Text="{Binding TeamName, Mode=TwoWay}"/>
-						<TextBlock Text=" | "/>
-						<telerik:RadMaskedTextBox MaskType="Numeric" Mask="#" Value="{Binding Count, Mode=OneWay}"/>
+						<TextBlock Text=" | "/>						
+						<telerik:RadMaskedNumericInput Mask="#" Value="{Binding Count, Mode=OneWay}"/>
 					</StackPanel>
 				</Grid>
 			</DataTemplate>
 		{{endregion}}
 
-	>In order to use the Telerik __RadMaskedTextBox__ you need to add a reference to the __Telerik.Windows.Controls.Input__ assembly in your user control.
+	>In order to use the Telerik __RadMaskedNumericInput__ you need to add a reference to the __Telerik.Windows.Controls.Input__ assembly in your user control.
 		  
 
 	These are the three __DataTemplates__, which will be used as edit templates. Accordingly, when the object type is League, then the __LeagueItemEditTemplate__ will be applied; when the object type is __Division__, then the __DivisionItemEditTemplate__ will be applied; when the object type is __Team__, then the __TeamItemEditTemplate__ will be applied.

--- a/controls/radtreeview/populating-with-data/item-edit-template.md
+++ b/controls/radtreeview/populating-with-data/item-edit-template.md
@@ -127,16 +127,16 @@ In this tutorial an __ItemEditTemplate__ will be created with Expression Blend.
 
 	>Defining the template in the Application section makes it reusable from everywhere in the application.
 
-* Drag and drop the controls you need for the template and configure their properties. In the example are used a __TextBox__ and a __RadMaskedTextBox__
+* Drag and drop the controls you need for the template and configure their properties. In the example are used a __TextBox__ and a __RadMaskedNumericInput__
 	![](images/RadTreeView_TemplatingItemEditTemplate_040.PNG)
 
-* Configure the binding for the __Text__ property of the __TextBox__, and for the __Value__ property of the __RadMaskedTextBox__. 
+* Configure the binding for the __Text__ property of the __TextBox__, and for the __Value__ property of the __RadMaskedNumericInput__. 
 	![](images/RadTreeView_TemplatingItemEditTemplate_050.PNG)
 
 * Bind the __TextBox Text__ property to the __Name__ property of the business object and set the binding to be __TwoWay__. 
 	![](images/RadTreeView_TemplatingItemEditTemplate_060.PNG)
 
-* Do the same for the __Value__ property of the __RadMaskedTextBox__.
+* Do the same for the __Value__ property of the __RadMaskedNumericInput__.
 
 Here is the final XAML:
 
@@ -149,7 +149,7 @@ Here is the final XAML:
 	  <StackPanel Orientation="Horizontal">
 	
 	   <TextBox Text="{Binding Name, Mode=TwoWay}"/>
-	   <telerikInput:RadMaskedTextBox MaskType="Numeric" Mask="#" Value="{Binding Count, Mode=OneWay}"/>
+	   <telerik:RadMaskedNumericInput Mask="#" Value="{Binding Count, Mode=OneWay}"/>
 	
 	  </StackPanel>
 	


### PR DESCRIPTION
...e new RadMaskedNumericInput instead of RadMaskedTextBox which is removed from the UI for WPF/Silverlight suite

[230563]TreeView Item Edit Template article must be updated