### PR TITLE
Update disable-ieditableobject-support.md

### DIFF
--- a/controls/radgridview/managing-data/how-to/disable-ieditableobject-support.md
+++ b/controls/radgridview/managing-data/how-to/disable-ieditableobject-support.md
@@ -8,10 +8,10 @@ published: True
 position: 1
 ---
 
-# Disable IEditableObject Support in RadGridView's Data Engine
-
-As of Q1 2016 we've introduced the **ShouldRespectIEditableObject** property. The default value is **True**. Setting it to false will prevent RadGridView's DataEngine from calling the [**IEditableObject**](https://msdn.microsoft.com/en-us/library/system.componentmodel.ieditableobject(v=vs.110).aspx) methods - **BeginEdit()**, **CancelEdit()** and **EndEdit()**.
-
+# Disable IEditableObject Support in the RadGridView Data Engine
+<<Comment: If the property you are introducing is called ShouldRespectIEditableObject, why doesn't this name appear in the title, description or the heading 1 for the page? I think the SEO would be better if you did. Also, for better SEO, RadGridView and data engine should also appear in the description. Finally, for SEO, I think you should try to avoid using 's to make a key SEO word posessive. More people will type RadGridView Data Engine into a search query than RadGridView's Data Engine.>> 
+As of Q1 2016, we've introduced the **ShouldRespectIEditableObject** property. The default value is **True**. Setting it to false will prevent the RadGridView Data Engine from calling the [**IEditableObject**](https://msdn.microsoft.com/en-us/library/system.componentmodel.ieditableobject(v=vs.110).aspx) methods - **BeginEdit()**, **CancelEdit()** and **EndEdit()**.
+<<Comment: I assume Data Engine is two words because you used it that way earlier. If it is one word, change the tag and the H1 to match. Also, why do you have **True** for one value and false (not capitalized, not bold) elsewhere? Generally the doumentation should standardize on one and then discuss it with the team and write the convention down somewhere that others will look. >>
 >Setting **ShouldRespectIEditableObject** to false will only prevent the IEditableObject methods of the object implementing the interface. RadGridView's **BeginEdit()**, **CancelEdit()** and **EndEdit()** methods will still be executed and the respective [events]({%slug gridview-events-edit%}) will be raised.
 
 #### __[XAML] Example 1: Setting ShouldRespectIEditableObject__


### PR DESCRIPTION
Several small edits and several comments about better SEO inline. Please address and then remove my comments.

I suggested to Marin on the AJAX team that it might help all of your teams to have a private repository of capitalization and style rules (like whether a value should be written as **True** or false) in GitHub that we all have access to. It would be GREAT if your teams built a sort of style check tool just to check capitalization and style rules like this before articles get published in GitHub. It could immensely help all of the Telerik teams that write documentation if everyone used it. I use a tool in Word that flags many style rule issues (but I don't run it on Telerik documentation because there isn't enough consistency to enforce and it doesn't like Markdown syntax). 
Here is an idea: if Telerik created a great style and capitalization tool that works for GitHub that you build for your own documentation, you could sell the tool to customers. Tools like that don't get out of date fast (grammar rules are very slow to change, but if you made a dictionary that allowed customers to add their own terms and style rules, that would be the best option) and you wouldn't have to do much marketing -- it's an easy add-on purchase for your current customer lists.  You could even give basic version away for a while until it has good name recognition and then sell a Pro version.