### PR TITLE
Add information about overriding the DctDecode class in PdfViewer

### DIFF
--- a/controls/radpdfviewer/customization-and-extensibility/customize-pdf-rendering.md
+++ b/controls/radpdfviewer/customization-and-extensibility/customize-pdf-rendering.md
@@ -135,11 +135,11 @@ The result that a custom filter should return depends on the type of the filter.
 
 * **JBIG2Decode**
 
+* **JPXDecode**
+
 * **DCTDecode**
 	>You can override the DctDecode class and its Decode() method. This will enable you to call the DecodeWithJpegDecode() method in order to achieve backward compatibility by using Telerik's JpegDecoder. In some cases, this approach decodes faster than the BitmapImage class, which is currently used to decode the images.
 
-
-* **JPXDecode**
 
 RadPdfViewer expects these filters to return data that depends on the decoded object's colors space and bits per component (there are such properties in the __decodedObject__). The resulting byte array should contain exactly BitsPerComponent bits for each color component in the color space. For example, if you have RGB color space and 8 bits per component, the resulting byte array should contains a single byte value for each Red, Green and Blue value (for each pixel) in the decoded image.
         

--- a/controls/radpdfviewer/customization-and-extensibility/customize-pdf-rendering.md
+++ b/controls/radpdfviewer/customization-and-extensibility/customize-pdf-rendering.md
@@ -136,11 +136,13 @@ The result that a custom filter should return depends on the type of the filter.
 * **JBIG2Decode**
 
 * **DCTDecode**
+	>You can override the DctDecode class and its Decode() method. This will enable you to call the DecodeWithJpegDecode() method in order to achieve backward compatibility by using Telerik's JpegDecoder. In some cases, this approach decodes faster than the BitmapImage class, which is currently used to decode the images.
+
 
 * **JPXDecode**
 
 RadPdfViewer expects these filters to return data that depends on the decoded object's colors space and bits per component (there are such properties in the __decodedObject__). The resulting byte array should contain exactly BitsPerComponent bits for each color component in the color space. For example, if you have RGB color space and 8 bits per component, the resulting byte array should contains a single byte value for each Red, Green and Blue value (for each pixel) in the decoded image.
         
-# See Also 
+## See Also 
 
 * [Custom Document Presenter]({%slug radpdfviewer-customization-and-extensibility-custom-document-presenter%})


### PR DESCRIPTION
A note is added to dеscribe different approaches for decoding images with DCTDecode filter.