### PR TITLE
Changing TextBox to TextBlock on GridViewColumnGroup HeaderTemplate

### DIFF
--- a/controls/radgridview/columns/column-groups.md
+++ b/controls/radgridview/columns/column-groups.md
@@ -89,7 +89,7 @@ You can define a __custom header__ for the __GridViewColumnGroup__ through its H
 	<telerik:GridViewColumnGroup Name="Data">
 	    <telerik:GridViewColumnGroup.HeaderTemplate>
 	        <DataTemplate>
-	            <TextBox Text="Data"/>
+	            <TextBlock Text="Data"/>
 	        </DataTemplate>
 	    </telerik:GridViewColumnGroup.HeaderTemplate>
 	</telerik:GridViewColumnGroup>


### PR DESCRIPTION
TextBox does not make sense in the header template. TextBlock is the correct control to use to replace default the GridViewColumnGroup HeaderTemplate.