### PR TITLE
Add link to Setting a Theme article

### DIFF
--- a/styling-and-appearance/styling-apperance-setting-a-theme-overview.md
+++ b/styling-and-appearance/styling-apperance-setting-a-theme-overview.md
@@ -10,7 +10,7 @@ position: 0
 
 # Setting a Theme
 
-__UI for {% if site.site_name == 'Silverlight' %}Silverlight{% endif %}{% if site.site_name == 'WPF' %}WPF{% endif %}__ suite provides a variety of themes that will help you achieve outstanding visual appearance and great user experience. Before choosing what theme to apply and what approach to take in order to do so, you might find it useful to familiarize with the [Themes Concept](#what-is-a-theme) and their [Distribution](#where-can-a-theme-be-found).
+__UI for {% if site.site_name == 'Silverlight' %}Silverlight{% endif %}{% if site.site_name == 'WPF' %}WPF{% endif %}__ suite provides a [variety of themes]({%slug common-styling-appearance-available-themes%}) that will help you achieve outstanding visual appearance and great user experience. Before choosing what theme to apply and what approach to take in order to do so, you might find it useful to familiarize with the [Themes Concept](#what-is-a-theme) and their [Distribution](#where-can-a-theme-be-found).
 
 The theming mechanism makes it really easy for you to change the overall appearance of your application. Furthermore, it is simple for you to make customizations, assemblies have smaller size and modifications through **Blend** is supported. 
 


### PR DESCRIPTION
It's useful to have link to the article with the available themes just at the beginning of this long article.