### PR TITLE
!Compile

### DIFF
--- a/controls/radgridview/export/export.md
+++ b/controls/radgridview/export/export.md
@@ -49,7 +49,7 @@ __Example 1__ shows how to display a "Save File" dialog asking the user to save 
 	        Filter = String.Format("{1} files (*.{0})|*.{0}|All files (*.*)|*.*", extension, "Excel"),
 	        FilterIndex = 1
 	    };
-	    if (dialog.ShowDialog() == true)
+	    if (dialog.ShowDialog() == DialogResult.OK)
 	    {
 	        using (Stream stream = dialog.OpenFile())
 	        {


### PR DESCRIPTION
Line 52: 
if (dialog.ShowDialog() == true) - this would never be compiled. ShowDialog() return result should NOT be compared to booleans. At least the compiler complains about it. 
The correct comparison is:
if (dialog.ShowDialog() == DialogResult.OK)
In all snippets for the export of RadGridView this comparison should be changed.