### PR TITLE
Changed minimum VS version requirement

### DIFF
--- a/cloud-integration/amazon-web-services/overview.md
+++ b/cloud-integration/amazon-web-services/overview.md
@@ -30,6 +30,6 @@ Here are the currently available topics:
 
 ## Prerequisites
 
-In order to build and run the examples from the articles you will need an active AWS account. Your system should have .NET Framework 4 or later and Visual Studio 2010 or later. In addition, we use the [AWS SDK for .NET](https://aws.amazon.com/sdk-for-net/), which provides everything you need in order to build your application using Visual Studio. You will need to set up a security profile for DynamoDB in Visual Studio. 
+In order to build and run the examples from the articles you will need an active AWS account. Your system should have .NET Framework 4 or later and Visual Studio 2013 or later. In addition, we use the [AWS SDK for .NET](https://aws.amazon.com/sdk-for-net/), which provides everything you need in order to build your application using Visual Studio. You will need to set up a security profile for DynamoDB in Visual Studio. 
 
 The [Getting Started]({%slug cloud-services/aws/getting-started%}) article shows how you can setup your environment.


### PR DESCRIPTION
AWS SDK for .NET only has versions for VS 2013 or newer so it would make sense to mention that as the minimum version for following the tutorials.