### PR TITLE
Add missing dependency

### DIFF
--- a/controls/radwebcam/getting-started.md
+++ b/controls/radwebcam/getting-started.md
@@ -17,6 +17,7 @@ This tutorial will walk you through the creation of a sample application that co
 In order to use __RadWebCam__, you will need to add references to the following assemblies:
 * __Telerik.Windows.Controls__
 * __Telerik.Windows.Controls.Media__
+* __Telerik.Windows.Controls.Navigation__
 * __Telerik.Windows.MediaFoundation__
 * __MediaFoundation__: This dll is located in the *UI for WPF installation folder/Binaries or Binaries.NoXaml/{.NET Version}/MediaFoundation* folder.
 * __SharpDX__: This dll is located in the *UI for WPF installation folder/Binaries or Binaries.NoXaml/{.NET Version}/SharpDX* folder.


### PR DESCRIPTION
Telerik.Windows.Controls.Navigation is needed on opening settings of RadWebCam.