### PR TITLE
Update the Commands article of RadScheduleView with missing commands

### DIFF
--- a/controls/radscheduleview/features/commands.md
+++ b/controls/radscheduleview/features/commands.md
@@ -10,7 +10,7 @@ position: 9
 
 # Commands
 
-__RadScheduleView__ exposes its functionality through various commands that can be executed on its behalf. All commands are placed in the static class __RadScheduleViewCommands__. The purpose of this tutorial is to show you all of the commands exposed by the __RadScheduleViewCommands__ class and how to execute them.
+`RadScheduleView` exposes its functionality through various commands that can be executed on its behalf. All commands are placed in the static class `RadScheduleViewCommands`. The purpose of this tutorial is to show you all of the commands exposed by the RadScheduleViewCommands class and how to execute them.
 
 * [CreateAppointment / CreateAppointmentWithDialog Commands](#createappointment--createappointmentwithdialog-commands)
 
@@ -44,9 +44,9 @@ __RadScheduleView__ exposes its functionality through various commands that can 
 
 ## CreateAppointment / CreateAppointmentWithDialog Commands
 
-When you want to create a new appointment and show the EditAppointmentDialog, then you need to use the __CreateAppointment__ or __CreateAppointmentWithDialog__ commands. If no parameter is passed, the __SelectedSlot__ of __RadScheduleView__ will be used for the new appointment start and end dates. If you want to explicitly specify which will be the start and end date you should pass a parameter of type __IDateSpan__ (for example Slot is an __IDateSpan__).
+When you want to create a new appointment and show the EditAppointmentDialog, then you need to use the `CreateAppointment` or `CreateAppointmentWithDialog` commands. If no parameter is passed, the `SelectedSlot` of `RadScheduleView` will be used for the new appointment start and end dates. If you want to explicitly specify which will be the start and end date you should pass a parameter of type `IDateSpan` (for example Slot is an IDateSpan).
 
-The difference between both commands is when neither the parameter nor the __SelectedSlot__ is set. In this case only the __CreateAppointmentWithDialog__ command will show EditAppointmentDialog for the first visible slot, while __CreateAppointment__ command won’t be executed.
+The difference between both commands is when neither the parameter nor the `SelectedSlot` is set. In this case only the `CreateAppointmentWithDialog` command will show EditAppointmentDialog for the first visible slot, while `CreateAppointment` command won’t be executed.
 
 #### __C#__  
 {{region radscheduleview-features-commands_0}}
@@ -56,7 +56,7 @@ The difference between both commands is when neither the parameter nor the __Sel
 
 ## CreateInlineAppointment Command
 
-Use it when you want to create a new appointment via the inline editing. If no parameter is passed, the __SelectedSlot__ of __RadScheduleView__ will be used for the new appointment start and end dates. If you want to explicitly specify which will be the start and end date you should pass a parameter of type __IDateSpan__ (for example __Slot__ is an __IDateSpan__):
+Use it when you want to create a new appointment via the inline editing. If no parameter is passed, the `SelectedSlot` of `RadScheduleView` will be used for the new appointment start and end dates. If you want to explicitly specify which will be the start and end date you should pass a parameter of type `IDateSpan` (for example `Slot` is an IDateSpan):
 
 #### __C#__   
 {{region radscheduleview-features-commands_1}}
@@ -67,7 +67,7 @@ Use it when you want to create a new appointment via the inline editing. If no p
 
 ## EditAppointment Command
 
-Use it when you want to show the edit dialog for an appointment. If no parameters are passed it uses the __SelectedAppointment__ of __RadScheduleView__. By default this command is bound to double click on appointment.
+Use it when you want to show the edit dialog for an appointment. If no parameters are passed it uses the `SelectedAppointment` of `RadScheduleView`. By default this command is bound to double click on appointment.
 
 #### __C#__  
 {{region radscheduleview-features-commands_2}}
@@ -76,7 +76,7 @@ Use it when you want to show the edit dialog for an appointment. If no parameter
 
 ## DeleteAppointment Command
 
-When you want to remove an appointment from __AppointmentsSource__ collection, then you need to use the __DeleteAppointment__ command. If no parameter is passed the __SelectedAppointment__ will be used.
+When you want to remove an appointment from `AppointmentsSource` collection, then you need to use the `DeleteAppointment` command. If no parameter is passed the `SelectedAppointment` will be used.
 
 #### __C#__  
 {{region radscheduleview-features-commands_3}}
@@ -85,19 +85,19 @@ When you want to remove an appointment from __AppointmentsSource__ collection, t
 
 ## EditRecurrenceRule Command
 
-When you want to open EditRecurrenceDialog, then you need to use the __EditRecurrenceRule__ command. This command is used mainly in EditAppointmentDialog. 
+When you want to open EditRecurrenceDialog, then you need to use the `EditRecurrenceRule` command. This command is used mainly in EditAppointmentDialog. 
 
 ## DeleteRecurrenceRule Command
 
-When you want to remove the recurrence, then you need to use __DeleteRecurrenceRule__ Command. The command is used mainly in EditRecurrenceDialo
+When you want to remove the recurrence, then you need to use `DeleteRecurrenceRule` Command. The command is used mainly in EditRecurrenceDialo
 
 ## EditParentAppointment Command
 
-If you want to edit the master appointment, when the user has initiated editing of an occurrence or exception from appointment's RecurrenceRule, you need to use the __EditParentAppointment__ command. This command is used mainly in EditAppointmentDialog.
+If you want to edit the master appointment, when the user has initiated editing of an occurrence or exception from appointment's RecurrenceRule, you need to use the `EditParentAppointment` command. This command is used mainly in EditAppointmentDialog.
 
 ## SetDayViewMode Command
 
-Executing this command will result in setting the RadScheduleView’s __ActiveViewDefinition__ property to __DayViewDefinition__.
+Executing this command will result in setting the RadScheduleView’s `ActiveViewDefinition` property to `DayViewDefinition`.
 
 #### __C#__  
 {{region radscheduleview-features-commands_4}}
@@ -106,7 +106,7 @@ Executing this command will result in setting the RadScheduleView’s __ActiveVi
 
 ## SetWeekViewMode Command
 
-Executing this command will result in setting the RadScheduleView's __ActiveViewDefinition__ property to __WeekViewDefinition__.
+Executing this command will result in setting the RadScheduleView's `ActiveViewDefinition` property to `WeekViewDefinition`.
 
 #### __C#__  
 {{region radscheduleview-features-commands_5}}
@@ -115,7 +115,7 @@ Executing this command will result in setting the RadScheduleView's __ActiveView
 
 ## SetMonthViewMode Command
 
-Executing this command will result in setting the RadScheduleView's __ActiveViewDefinition__ property to __MonthViewDefinition__.
+Executing this command will result in setting the RadScheduleView's `ActiveViewDefinition` property to `MonthViewDefinition`.
 
 #### __C#__  
 {{region radscheduleview-features-commands_6}}
@@ -124,7 +124,7 @@ Executing this command will result in setting the RadScheduleView's __ActiveView
 
 ## SetTimelineViewMode Command
 
-Executing this command will result in setting the RadScheduleView's __ActiveViewDefinition__ property to __TimelineViewDefinition__.
+Executing this command will result in setting the RadScheduleView's `ActiveViewDefinition` property to `TimelineViewDefinition`.
 
 #### __C#__
 {{region radscheduleview-features-commands_7}}
@@ -133,7 +133,7 @@ Executing this command will result in setting the RadScheduleView's __ActiveView
 
 ## IncreaseVisibleDateLarge /  DecreaseVisibleDateLarge Commands
 
-Increases/decreases the first visible date with n months or days, where n is the value of the __LargeChangeInterval__ property of the ActiveViewDefinition. Executing this command is equivalent to changing the displayed days using the navigation buttons.
+Increases/decreases the first visible date with n months or days, where n is the value of the `LargeChangeInterval` property of the ActiveViewDefinition. Executing this command is equivalent to changing the displayed days using the navigation buttons.
 
 #### __C#__
 {{region radscheduleview-features-commands_8}}
@@ -143,7 +143,7 @@ Increases/decreases the first visible date with n months or days, where n is the
 
 ## SetAppointmentImportance Command
 
-When you want to set the Appointment's Importance property, then you need to execute the __SetAppointmentImportance__ command. This command is used primely in EditAppointmentDialog.
+When you want to set the Appointment's Importance property, then you need to execute the `SetAppointmentImportance` command. This command is used primely in EditAppointmentDialog.
 
 ## GoToPreviousAppointment / GoToNextAppointment Commands
 
@@ -157,9 +157,53 @@ Use these commands when you want to navigate to the previous/next appointment ou
 
 ## SetToday Command
 
-You can use the __SetToday__ command to navigate to the current day in the active view definition.
+You can use the `SetToday` command to navigate to the current day in the active view definition.
 
 #### __C#__  
 {{region radscheduleview-features-commands_10}}
 	RadScheduleViewCommands.SetToday.Execute(null, ScheduleView);
+{{endregion}}
+
+## RestoreOriginalOccurrence Command
+
+You can use the `RestoreOriginalOccurrence` command to revert the exception to the original occurrence.
+
+## SetAgendaViewMode Command
+
+Executing this command will result in setting the RadScheduleView's `ActiveViewDefinition` property to `AgendaViewDefinition`.
+
+## CommitEditAppointment Command
+
+The `CommitEditAppointment` command allows you to commit the currently edited appointment.
+
+#### __[C#]__
+{{region radscheduleview-features-commands-11}}
+	RadScheduleViewCommands.CommitEditAppointment.Execute(appointment, ScheduleView);
+{{endregion}}
+
+## BeginEditAppointment Command
+
+You can use the `BeginEditAppointment` command to begin an editing proccess of an appointment.
+
+#### __[C#]__
+{{region radscheduleview-features-commands-12}}
+	RadScheduleViewCommands.BeginEditAppointment.Execute(appointment, ScheduleView);
+{{endregion}}
+
+## BeginInlineEditing Command
+
+The `BeginInlineEditing` command starts an inline editing process of an appointment.
+
+#### __[C#]__
+{{region radscheduleview-features-commands-13}}
+	RadScheduleViewCommands.BeginInlineEditing.Execute(appointment, ScheduleView);
+{{endregion}}
+
+## CancelEditAppointment Command
+
+The `CancelEditAppointment` allows you to cancel the editting of the current appointment and revert the applied changes.
+
+#### __[C#]__
+{{region radscheduleview-features-commands-14}}
+	RadScheduleViewCommands.CancelEditAppointment.Execute(appointment, ScheduleView);
 {{endregion}}


### PR DESCRIPTION
Of the missing commands, only the ones that have CanExecute and Executed logic are included.