### PR TITLE
Map: Add attribution copyright information for providers

### DIFF
--- a/controls/radmap/features/providers/arcgis.md
+++ b/controls/radmap/features/providers/arcgis.md
@@ -10,11 +10,11 @@ position: 1
 
 # ArcGIS Online Map Provider
 
-The [ArcGIS online services](http://www.esri.com/software/arcgis/arcgisonline/maps/maps-and-map-layers) can be used via the __ArcGisMapProvider__ class.
+The [ArcGIS online services](http://www.esri.com/software/arcgis/arcgisonline/maps/maps-and-map-layers) can be used via the `ArcGisMapProvider` class.
 
 >tip To use the [ArcGIS vector tile services](https://developers.arcgis.com/rest/services-reference/enterprise/vector-tile-service.htm) refer to the [Migrating to Vector Tile Map Provider](#migrating-to-vector-tile-map-provider) section of this article.
 
-Currently the ArcGIS map provider support six modes which specify the type of appearance of the map can and be set using the __Mode__ property:        
+Currently the ArcGIS map provider support six modes which specify the type of appearance of the map can and be set using the `Mode` property:        
 
 1. Aerial
 2. Physical
@@ -23,9 +23,9 @@ Currently the ArcGIS map provider support six modes which specify the type of ap
 5. Terrain
 6. Topographic
 
-The following example of the __ArcGisMapProvider__ definition uses the __Physical__ mode:
+The following example of the `ArcGisMapProvider` definition uses the `Physical` mode:
 
-#### __XAML__
+#### __[XAML] Defining the ArcGisMapProvider in XAML__
 {{region xaml-radmap-features-providers-arcgis-0}}
 	<telerik:RadMap x:Name="radMap" ZoomLevel="1">
 		<telerik:RadMap.Provider>
@@ -34,23 +34,35 @@ The following example of the __ArcGisMapProvider__ definition uses the __Physica
 	</telerik:RadMap>
 {{endregion}}
 
-#### __C#__
+#### __[C#] Defining the ArcGisMapProvider in code-behind__
 {{region cs-radmap-features-providers-arcgis-1}}
 	ArcGisMapProvider provider = new ArcGisMapProvider();
 	provider.Mode = ArcGisMapMode.Physical;
 	this.radMap.Provider = provider;
 {{endregion}}
 
-#### __VB.NET__	
+#### __[VB.NET] Defining the ArcGisMapProvider in code-behind__	
 {{region vb-radmap-features-providers-arcgis-2}}
 	Dim provider As New ArcGisMapProvider ()
 	provider.Mode = ArcGisMapMode.Physical
 	Me.radMap.Provider = provider
 {{endregion}}
 
->important As of **April 16, 2019**, ArcGIS Online services only accept connections using [TLS 1.2](https://docs.microsoft.com/en-us/mem/configmgr/core/plan-design/security/enable-tls-1-2). Thus, you need to explicitly set the **ServicePointManager.SecurityProtocol** property if you're using a .NET Framework version prior to **4.7**.
+__ArcGisMapProvider when using the `Physical` mode__
 
-#### __C#__
+![rcGisMapProvider when using the Physical mode](images/RadMap_Features_Providers_ArcGIS.png)
+
+## Attribution Copyright Label
+
+When using the ArcGisMapProvider, you have to display an attribution copyright label to the ArcGis services. To learn more about the accurate copyright label's content, please refer to the [Esri and data attribution](https://developers.arcgis.com/documentation/esri-and-data-attribution/) article.
+
+>tip To learn how to customize the RadMap to allocate space for displaying an element containing a sample attribution copyright label, check this [article]({%slug kb-map-copyright-label%}).
+
+## Security Protocol
+
+ArcGIS Online services only accept connections using [TLS 1.2](https://docs.microsoft.com/en-us/mem/configmgr/core/plan-design/security/enable-tls-1-2). Thus, you need to explicitly set the `ServicePointManager.SecurityProtocol` property if you're using a .NET Framework version prior to __4.7__.
+
+#### __[C#] Setting the ServicePointManager.SecurityProtocol__
 {{region cs-radmap-features-providers-arcgis-3}}
 	public App()
 	{
@@ -59,7 +71,7 @@ The following example of the __ArcGisMapProvider__ definition uses the __Physica
 	}
 {{endregion}}
 
-#### __VB.NET__	
+#### __[VB.NET] Setting the ServicePointManager.SecurityProtocol__
 {{region vb-radmap-features-providers-arcgis-4}}
 	Partial Public Class App
 		Inherits Application
@@ -71,19 +83,14 @@ The following example of the __ArcGisMapProvider__ definition uses the __Physica
 	End Class
 {{endregion}}
 
-Here is a snapshot of the map that appears when using the `Physical` mode:
-
-![Rad Map Features Providers ArcGIS](images/RadMap_Features_Providers_ArcGIS.png)
-
-For comparison, the following snapshot demonstrates the appearance of the map for the __Street__ mode:
+For comparison, the following snapshot demonstrates the appearance of the map for the `Street` mode:
 
 ![Rad Map Features Providers ArcGIS Street](images/RadMap_Features_Providers_ArcGIS_Street.png)
 
-The __ArcGisMapProvider__ also allows the user to change the map mode using the **Map View** button of the toolbar.
+The ArcGisMapProvider also allows the user to change the map mode using the __Map View__ button of the toolbar.
 
 ![Rad Map Features Providers ArcGIS Config](images/RadMap_Features_Providers_ArcGIS_Config.png)
 
-{% if site.framework_name == 'WPF' %}
 ## Migrating to Vector Tile Map Provider
 
 To migrate to a vector-based tile provider that uses the [ArcGIS vector tile services](https://developers.arcgis.com/rest/services-reference/enterprise/vector-tile-service.htm) you can create a custom vector tile providers. The [Custom Vector Tile Provider]({%slug radmap-features-custom-vector-tile-provider%}) article demonstrates how to do this.
@@ -97,7 +104,6 @@ Additional to this, as of 2023, part of the ArcGIS raster-based services are obs
 | Streets (world streets) | https://www.arcgis.com/home/item.html?id=3b93337983e9436f8db950e38a8629af |  https://www.arcgis.com/home/item.html?id=de26a3cf4cc9451298ea173c4b324736 |
 | Terrain (world terrain) | https://www.arcgis.com/home/item.html?id=c61ad8ab017d49e1a82f580ee1298931 |  no longer supported |
 | Topographic (world topographic) | https://www.arcgis.com/home/item.html?id=30e5fe3149c34df1ba922e6f5bbf808f |  https://www.arcgis.com/home/item.html?id=7dc6cea0b1764a1f9af2e679f642f0f5 |
-{% endif %}
 
 ## See Also
  * [BingRestMapProvider]({%slug radmap-features-providers-bing-rest-map%})

--- a/controls/radmap/features/providers/azuremapprovider.md
+++ b/controls/radmap/features/providers/azuremapprovider.md
@@ -33,6 +33,12 @@ __RadMap with AzureMapProvider__
 
 >If the provider’s initialization fails, the AzureMapProvider will raise its `InitializationFaulted` event. The event can be fired for example, when the internet connection is lost or when the service is unavailable. The event arguments are of type `InitializationFaultEventArgs` type. The arguments provide an `Error` property which contains the exception that is thrown while initialization.
 
+## Attribution Copyright Label
+
+When using the AzureMapProvider, you have to display an attribution copyright label to the Azure Maps services. To learn more about the accurate copyright label's content, please refer to this [article](https://learn.microsoft.com/en-us/azure/azure-maps/how-to-show-attribution).
+
+>tip To learn how to customize the RadMap to allocate space for displaying an element containing a sample attribution copyright label, check this [article]({%slug kb-map-copyright-label%}).
+
 ## Specifying the TileSet
 
 The Azure Maps services provide a set of different map layers ([tilesets](https://learn.microsoft.com/en-us/rest/api/maps/render-v2/get-map-tileset?tabs=HTTP#tilesetid)). The AzureMapProvider class will allow you to specify one of these raster or vector tilesets, by setting the `TileSet` property.

--- a/controls/radmap/features/providers/bing-rest-map-provider/bing-map-rest.md
+++ b/controls/radmap/features/providers/bing-rest-map-provider/bing-map-rest.md
@@ -10,23 +10,20 @@ position: 0
 
 # Bing Map Rest Provider
 
-The RadMap control supports visualizing tile data using the Bind Maps Rest imagery service. In order to create an instance of the __BingRestMapProvider__ you have to use the third overload of its constructor. This way you can easily pass the required parameters - map mode, labels visibility and a __Bing Maps Key__. The most important of them is the __Bing Maps Key__ parameter. Without supplying a valid key you will not be able to visualize the map inside the __RadMap__ control. In order to learn how to obtain one, please read [Accessing the Control Using a Bing Maps Key](https://learn.microsoft.com/en-us/previous-versions/bing/wpf-control/hh709042(v=msdn.10)).
+The `RadMap` control supports visualizing tile data using the Bind Maps Rest imagery service. In order to create an instance of the `BingRestMapProvider` you have to use the third overload of its constructor. This way you can easily pass the required parameters - map mode, labels visibility and a __Bing Maps Key__. The most important of them is the __Bing Maps Key__ parameter. Without supplying a valid key you will not be able to visualize the map inside the RadMap control. In order to learn how to obtain one, please read [Accessing the Control Using a Bing Maps Key](https://learn.microsoft.com/en-us/previous-versions/bing/wpf-control/hh709042(v=msdn.10)).
 
 >The RadMap BingRestMapProvider is based on the Bing Maps [Imagery API](https://msdn.microsoft.com/en-us/library/ff701721.aspx?f=255&MSPPError=-2147217396).
 
-Here is a list of the key properties which are used by __BingRestMapProvider__:        
+Here is a list of the key properties which are used by BingRestMapProvider:      
 
-* __ApplicationId__: Gets or sets __Bing Maps Key__.            
+* `ApplicationId`&mdash;Gets or sets __Bing Maps Key__.            
+* `IsLabelVisible`&mdash;Gets or sets value which indicates whether labels should be visible on the map.            
+* `Mode`&mdash;Gets or sets the mode defining how the map looks. You can choose between *Road*, *Aerial* and *Birdseye* options.            
+* `UseSession`&mdash;Gets or sets value which indicates whether Bing session should be used.           
 
-* __IsLabelVisible__: Gets or sets value which indicates whether labels should be visible on the map.            
+>If the provider’s initialization fails, the BingRestMapProvider will raise its `InitializationFaulted` event. The event can be fired for example, when the internet connection is lost or when the service is unavailable. The event arguments are of type `InitializationFaultEventArgs` type. The arguments provides an `Error` property which contains the exception which is thrown while initialization.          
 
-* __Mode__: Gets or sets the mode defining how the map looks. You can choose between *Road*, *Aerial* and *Birdseye* options.            
-
-* __UseSession__: Gets or sets value which indicates whether Bing session should be used.           
-
->If the provider’s initialization fails, the BingRestMapProvider will raise its InitializationFaulted event. The event can be fired for example, when the internet connection is lost or when the service is unavailable. The event arguments are of type __InitializationFaultEventArgs__ type. The arguments provides an __Error__ property which contains the exception which is thrown while initialization.          
-
-#### __[XAML] Example 1: Setting BingRestMapProvider in XAML__
+#### __[XAML] Setting BingRestMapProvider in XAML__
 {{region xaml-radmap-features-providers-bing-rest-map_0}}
 	<telerik:RadMap>
 		<telerik:RadMap.Provider>
@@ -35,33 +32,41 @@ Here is a list of the key properties which are used by __BingRestMapProvider__:
 	</telerik:RadMap>
 {{endregion}}
 
-#### __[C#] Example 2: Defining BingRestMapProvider programmaticaly__
+#### __[C#] Defining BingRestMapProvider programmaticaly__
 {{region cs-radmap-features-providers-bing-rest-map_1}}
 	BingRestMapProvider bingMap = new BingRestMapProvider( MapMode.Aerial, true, "Bing_Map_Key" );
 	this.radMap.Provider = bingMap;
 {{endregion}}
 
-#### __[VB.NET] Example 3: Defining BingRestMapProvider programmaticaly__
+#### __[VB.NET] Defining BingRestMapProvider programmaticaly__
 {{region vb-radmap-features-providers-bing-rest-map_2}}
 	Dim bingMap As New BingRestMapProvider(MapMode.Aerial, True, "Bing_Map_Key")
 	Me.radMap.Provider = bingMap
 {{endregion}}
 
-#### __Figure 1: Aerial mode with labels__
-![Rad Map Features Rest Providers 01](images/RadMap_Features_Rest_Providers_01.png)
+__Aerial mode with labels__
 
-You can disable labels using the __IsLabelVisible__ property. When you set it to *False* the labels disappear. __Figure 2__ is a snapshot of the Aerial mode for Bing Rest Map Provider when the labels are not visible:
+![RadMap BingRestMapProvider Aerial mode with labels](images/RadMap_Features_Rest_Providers_01.png)
 
-#### __Figure 2: Aerial mode without labels__
-![Rad Map Features Rest Providers 01 nolabels](images/RadMap_Features_Rest_Providers_02_nolabels.png)
+You can disable labels using the `IsLabelVisible` property. When you set it to *False* the labels disappear. The following snapshot of the Aerial mode for Bing Rest Map Provider when the labels are not visible:
+
+__Aerial mode without labels__
+
+![RadMap Features Aerial mode without labels](images/RadMap_Features_Rest_Providers_02_nolabels.png)
+
+## Attribution Copyright Label
+
+When using the BingRestMapProvider, you have to display an attribution copyright label to the Bing Rest Maps services. To learn more about the accurate copyright label's content, please refer to this [article](https://www.microsoft.com/en-us/maps/bing-maps/product/print-rights).
+
+>tip To learn how to customize the RadMap to allocate space for displaying an element containing a sample attribution copyright label, check this [article]({%slug kb-map-copyright-label%}).
 
 ## Language	
 
-Bing Rest Service provides culture parameter in its url address. This parameter can be used to specify a culture for your request. To change the current culture of the labels shown on the BingRestMapProvider, the __Language__ property of the RadMap control can be used.
+Bing Rest Service provides culture parameter in its url address. This parameter can be used to specify a culture for your request. To change the current culture of the labels shown on the BingRestMapProvider, the `Language` property of the RadMap control can be used.
 
 > For a list of supported cultures, see [Supported Culture Codes](https://docs.microsoft.com/en-us/bingmaps/rest-services/common-parameters-and-types/supported-culture-codes?redirectedfrom=MSDN).
 
-#### __[XAML] Example 4: Setting Language of RadMap in XAML__
+#### __[XAML] Setting Language of RadMap in XAML__
 {{region xaml-radmap-features-providers-bing-rest-map_3}}
 	<telerik:RadMap Language="fr-FR">
 		<telerik:RadMap.Provider>
@@ -70,8 +75,9 @@ Bing Rest Service provides culture parameter in its url address. This parameter 
 	</telerik:RadMap>
 {{endregion}}
 
-#### __Figure 3: BingRestMapProvider with French culture parameter__
-![Rad Map Language Rest Providers French](images/RadMap_Features_Rest_Providers_Language_03.png)
+__BingRestMapProvider with French culture parameter__
+
+![RadMap BingRestMapProvider with French culture parameter](images/RadMap_Features_Rest_Providers_Language_03.png)
 	
 ## See Also
  * [Providers Overview]({%slug radmap-features-providers%})

--- a/controls/radmap/features/providers/mapboxprovider.md
+++ b/controls/radmap/features/providers/mapboxprovider.md
@@ -19,13 +19,19 @@ In order to download data from the services, the provider needs to assign its `A
 #### __[XAML] Setting up MapBoxMapProvider__
 {{region radmap-features-mapboxprovider-0}}
 	<telerik:RadMap>
-		<telerik:RadMap.Provider>			
+		<telerik:RadMap.Provider>
 			<telerik:MapBoxMapProvider AccessToken="Your Access Token"/>
 		</telerik:RadMap.Provider>
 	</telerik:RadMap>
 {{endregion}}
 
 ![A picture showing RadMap with MapBoxMapProvider](images/radmap-features-mapboxprovider-0.png)
+
+## Attribution Copyright Label
+
+When using the MapBoxMapProvider, you have to display an attribution copyright label to the Mapbox services. To learn more about the accurate copyright label's content, please refer to the [MapBox Attribution](https://docs.mapbox.com/help/dive-deeper/attribution/) article.
+
+>tip To learn how to customize the RadMap to allocate space for displaying an element containing a sample attribution copyright label, check this [article]({%slug kb-map-copyright-label%}).
 
 ## Changing the Tile Set Mode
 
@@ -82,5 +88,4 @@ To assign a custom [style](https://docs.mapbox.com/mapbox-gl-js/style-spec/) `.j
 
 ## See Also 
 * [Vector Tile Providers]({%slug radmap-features-urivectortilemapprovider%})
-
 

--- a/controls/radmap/features/providers/osm-provider.md
+++ b/controls/radmap/features/providers/osm-provider.md
@@ -1,0 +1,70 @@
+---
+title: Open Street Maps Provider
+page_title: Open Street Maps Provider
+description: This article describes the support Open Street Maps services support in RadMap.
+slug: radmap-features-providers-osm-provider
+tags: providers,osm, openstreetmapprovider
+published: True
+position: 20
+---
+
+# Open Street Maps Provider
+
+`RadMap` supports displaying tile data from the [Open Street Map](https://www.openstreetmap.org/) services via the `OpenStreetMapProvider` class. You have the option of passing an API key to it. This key is needed for the Transport and Cycle maps, which come from [ThunderForest](https://www.thunderforest.com/). You can check the [following page](https://www.thunderforest.com/docs/apikeys/) in order to learn how to obtain an API key.
+
+#### __[XAML] OpenStreetMapProvider with API key in Xaml__
+{{region radmap-features-providers-3}}
+	<telerik:RadMap x:Name="radMap" ZoomLevel="1">
+		<telerik:RadMap.Provider>
+			<telerik:OpenStreetMapProvider APIKey="your-api-key" />
+		</telerik:RadMap.Provider>
+	</telerik:RadMap>
+{{endregion}}
+
+#### __[C#] OpenStreetMapProvider set in code__
+{{region radmap-features-providers-4}}
+	OpenStreetMapProvider openStreetMap = new OpenStreetMapProvider("your-api-key");
+	this.radMap.Provider = openStreetMap;
+{{endregion}}
+	
+#### __[VB] OpenStreetMapProvider set in code__
+{{region radmap-features-providers-5}}
+	Dim openStreetMap As New OpenStreetMapProvider("your-api-key")
+	Me.radMap.Provider = openStreetMap
+{{endregion}}
+
+## Attribution Copyright Label
+
+When using the OpenStreetMapProvider, you have to display an attribution copyright label to the Open Street Map services. To learn more about the accurate copyright label's content, please refer to the [OpenStreetMap Attribution Guideline](https://osmfoundation.org/wiki/Licence/Attribution_Guidelines) article.
+
+>tip To learn how to customize the RadMap to allocate space for displaying an element containing a sample attribution copyright label, check this [article]({%slug kb-map-copyright-label%}).
+
+## Setting a User-Agent
+
+The OpenStreetMapProvider class provides the option of passing a User-Agent header, which will be used in the web request for downloading the tiles from the Standard tile layer. This allows for compliance with the [OpenStreetMaps Tile Usage Policy](https://operations.osmfoundation.org/policies/tiles/). 
+
+>important If a User-Agent is not provided, the Standard layer tiles will not be downloaded.
+
+The following two examples demonstrate how you can pass such a User-Agent.
+
+#### __[XAML] Setting StandardModeUserAgent in Xaml__
+{{region radmap-features-providers-6}}
+	<telerik:RadMap x:Name="radMap" ZoomLevel="1">
+		<telerik:RadMap.Provider>
+			<telerik:OpenStreetMapProvider APIKey="your-api-key" StandardModeUserAgent="your custom user agent string" />
+		</telerik:RadMap.Provider>
+	</telerik:RadMap>
+{{endregion}}
+
+#### __[C#] Setting StandardModeUserAgent in code__
+{{region radmap-features-providers-7}}
+	OpenStreetMapProvider openStreeMapProvider = new OpenStreetMapProvider("your-api-key")
+	{
+		StandardModeUserAgent = "your custom user agent string"
+	};
+{{endregion}}
+	
+#### __[VB] Setting StandardModeUserAgent in code__
+{{region radmap-features-providers-7}}
+	Dim openStreeMapProvider As New OpenStreetMapProvider("your-api-key") With {.StandardModeUserAgent = "your custom user agent string"}
+{{endregion}}

--- a/controls/radmap/features/providers/providers.md
+++ b/controls/radmap/features/providers/providers.md
@@ -10,163 +10,82 @@ position: 0
 
 # Providers Overview
 
-The __RadMap__ control doesn't display a map on itself, it needs a map provider from which to consume the required data. Currently the __RadMap__ control supports a few providers:      
+The `RadMap` control doesn't display a map on itself, it needs a map provider from which to consume the required data. Currently the control supports a few providers:      
 
-* [Bing Maps](#bing-maps)
-
-* [ArcGIS](#arcgis-online-services)
-
-* [OpenStreet Maps](#openstreet-maps)
-
+* [Bing Maps](#bing-maps-provider)
+* [OpenStreet Maps](#openstreet-maps-provider)
 * [Empty Provider](#empty-provider)
+* [UriImageProvider](#uriimage-provider)
+* [ArcGIS](#arcgis-provider)
+* [Azure Maps](#azure-maps-provider)
+* [MapBox](#mapbox-provider)
 
-* [UriImageProvider](#uriimageprovider)
+>tip It is now possible to specify multiple map providers that will be displayed one over another through the `Providers` property of RadMap. Note that in multiple providers scenario the first (master) provider should be tiled provider without geographic limits set. Also, providers that have geographic limits and use tiled map sources should be limited with the `MapLayer.ZoomRange` attached property. Zoom range should be set into the reasonable value, so the size of the “map window” does not get excessive on the maximum allowed zoom level; otherwise loading of the tiles into the window will dramatically decrease performance of the application.        
 
->tip It is now possible to specify multiple map providers that will be displayed one over another through the __RadMap.Providers__ property. Note that in multiple providers scenario the first (master) provider should be tiled provider without geographic limits set. Also, providers that have geographic limits and use tiled map sources should be limited with the __MapLayer.ZoomRange__ attached property. Zoom range should be set into the reasonable value, so the size of the “map window” does not get excessive on the maximum allowed zoom level; otherwise loading of the tiles into the window will dramatically decrease performance of the application.        
+## Attribution Copyright Label
+
+Each provider of the RadMap control that displays third-party imagery data must display an attribution copyright label. For more information about the accurate copyright label's content, please refer to the attribution article of each of the third-party vendor.
+
+>tip To learn how to customize the RadMap to allocate space for displaying an element containing a sample attribution copyright label, check this [article]({%slug kb-map-copyright-label%}).
+
+## Common Providers API
 
 Here is a list of the most important common properties shared by all map providers:
 
-* __GeoBounds__ - Gets or sets region covered by map image (the region represented by map provider can be limited by geographic bounds now).          
+* `GeoBounds`&mdash;Gets or sets region covered by map image (the region represented by map provider can be limited by geographic bounds now).          
+* `Opacity`&mdash;Gets or sets the opacity factor for the respective provider imagery data.          
+* `Commands`&mdash;Gets the collection of the commands supported by the respective provider. This is useful if you want to customize the default command list (i.e. add / remove commands). You can find more information [here]({%slug radmap-howto-customize-commands%}).          
+* `CommandBindingCollection`&mdash;Gets collection of the command bindings.          
+* `SupportedSources`&mdash;Gets the IDs of the supported sources. This property can be used in scenarios where it is necessary to get the list of supported sources and execute some action based on them (e.g. enable or disable source specific commands in the command bar).
 
-* __Opacity__ - Gets or sets the opacity factor for the respective provider imagery data.          
+## Bing Maps Provider
 
-* __Commands__ - Gets the collection of the commands supported by the respective provider. This is useful if you want to customize the default command list (i.e. add / remove commands). You can find more information [here]({%slug radmap-howto-customize-commands%}).          
+The RadMap control provides the support to visual [Bing Maps](http://www.bing.com/maps/) tile data via the `BingRestMapProvider` (RESTful imagery service) class. 
 
-* __CommandBindingCollection__ - Gets collection of the command bindings.          
+For more information about the Bing Maps support, check the [Bing Map Rest Provider]({%slug radmap-features-providers-bing-rest-map%}) article.
 
-* __SupportedSources__ - Gets the IDs of the supported sources. This property can be used in scenarios where it is necessary to get the list of supported sources and execute some action based on them (e.g. enable or disable source specific commands in the command bar).
+## OpenStreet Maps Provider
 
-## Bing Maps
+RadMap supports displaying tile data from the [Open Street Map](https://www.openstreetmap.org/) services via the `OpenStreetMapProvider` class.
 
-The [Bing Maps](http://www.bing.com/maps/) can be used via the __BingRestMapProvider__ (RESTful imagery service) class. In order to create an instance of the __BingRestMapProvider__ you can use the third overload of its constructor. This way you can easily pass the required parameters - map mode, labels visibility and __Bing Maps Key__. The most important of them is the __Bing Maps Key__. Without supplying a valid key you won't be able to visualize the map inside the __RadMap__ control. In order to learn how to obtain one, please read the [Accessing the Control Using a Bing Maps Key](http://msdn.microsoft.com/en-us/library/ee681900.aspx) MSDN article.
-
-    
-
-#### __[XAML] Example 1: RadMap with BingMapProvider__
-{{region radmap-features-providers-0}}	
-	<telerik:RadMap x:Name="radMap" ZoomLevel="1">
-		<telerik:RadMap.Provider>
-			<telerik:BingRestMapProvider ApplicationId="Bing_Map_Key" Mode="Aerial" IsLabelVisible="True"/>
-		</telerik:RadMap.Provider>
-	</telerik:RadMap>
-{{endregion}}
-
-#### __[C#] Example 2: BingMapProvider set in code__
-{{region radmap-features-providers-1}}	
-	BingRestMapProvider bingMap = new BingRestMapProvider( MapMode.Aerial, true, "key" );
-	this.radMap.Provider = bingMap;
-{{endregion}}
-
-#### __[VB] Example 2: BingMapProvider set in code__
-{{region radmap-features-providers-2}}
-	Dim bingMap As New BingRestMapProvider(MapMode.Aerial, True, "key")
-	Me.radMap.Provider = bingMap
-{{endregion}}
-
-#### __Figure 1: Result from Examples 1 and 2__
-![Rad Map Features Providers 01](images/RadMap_Features_Providers_01.png)
-
-## OpenStreet Maps
-
-The [Open Street Maps](http://www.openstreetmap.org/) can be used via the __OpenStreetMapProvider__ class. Since the __R2 2019__ version, you have the option of passing an API key to it. This key is needed for the Transport and Cycle maps, which come from [ThunderForest](https://www.thunderforest.com/). You can check the [following page](https://www.thunderforest.com/docs/apikeys/) in order to learn how to obtain an API key.
-
-#### __[XAML] Example 3: OpenStreetMapProvider with API key in Xaml__
-{{region radmap-features-providers-3}}
-	<telerik:RadMap x:Name="radMap" ZoomLevel="1">
-		<telerik:RadMap.Provider>
-			<telerik:OpenStreetMapProvider APIKey="your-api-key" />
-		</telerik:RadMap.Provider>
-	</telerik:RadMap>
-{{endregion}}
-
-#### __[C#] Example 4: OpenStreetMapProvider set in code__
-{{region radmap-features-providers-4}}
-	OpenStreetMapProvider openStreetMap = new OpenStreetMapProvider("your-api-key");
-	this.radMap.Provider = openStreetMap;
-{{endregion}}
-	
-#### __[VB] Example 4: OpenStreetMapProvider set in code__
-{{region radmap-features-providers-5}}
-	Dim openStreetMap As New OpenStreetMapProvider("your-api-key")
-	Me.radMap.Provider = openStreetMap
-{{endregion}}
-
-Since the __R1 2020__ version, you have the option of passing a User-Agent header, which will be used in the web request for downloading the tiles from the Standard tile layer. This allows for compliance with the [OpenStreetMaps Tile Usage Policy](https://operations.osmfoundation.org/policies/tiles/). __Examples 5 and 6__ demonstrate how you can pass such a User-Agent.
-
-#### __[XAML] Example 5: Setting StandardModeUserAgent in Xaml__
-{{region radmap-features-providers-6}}
-	<telerik:RadMap x:Name="radMap" ZoomLevel="1">
-		<telerik:RadMap.Provider>
-			<telerik:OpenStreetMapProvider APIKey="your-api-key" StandardModeUserAgent="your custom user agent string" />
-		</telerik:RadMap.Provider>
-	</telerik:RadMap>
-{{endregion}}
-
-#### __[C#] Example 6: Setting StandardModeUserAgent in code__
-{{region radmap-features-providers-7}}
-	OpenStreetMapProvider openStreeMapProvider = new OpenStreetMapProvider("your-api-key")
-	{
-		StandardModeUserAgent = "your custom user agent string"
-	};
-{{endregion}}
-	
-#### __[VB] Example 6: Setting StandardModeUserAgent in code__
-{{region radmap-features-providers-7}}
-	Dim openStreeMapProvider As New OpenStreetMapProvider("your-api-key") With {.StandardModeUserAgent = "your custom user agent string"}
-{{endregion}}
-
-> If a User-Agent is not provided, the Standard layer tiles will not be downloaded.
+To learn more about the Open Street Map services support, check the [Open Street Map Provider]({%slug radmap-features-providers-osm-provider%}) article.
 
 ## Empty Provider
 
-Empty provider is a provider which doesn't connect to any real imagery services (Virtual Earth, Google etc). It provides definitions and methods which can be used to calculate positions of the framework elements, map shapes and pin points. By using this provider you can create map-relative applications which do not require visibility of the real map data (landscapes or roads), but which require visible elements to be positioned according to the geographical coordinates.
+The `EmptyProvider` is a provider which doesn't connect to any real imagery services (Virtual Earth, Google etc). It provides definitions and methods which can be used to calculate positions of the framework elements, map shapes and pin points. By using this provider you can create map-relative applications which do not require visibility of the real map data (landscapes or roads), but which require visible elements to be positioned according to the geographical coordinates.
 
->tip To learn more about the empty provider [read here]({%slug radmap-features-empty-provider%}).        
+To learn more about the EmptyProvider, check the [Empty Provider]({%slug radmap-features-empty-provider%}) article.        
 
-## UriImageProvider
+## UriImage Provider
 
-RadMap provides support for single image provider through the __UriImageProvider__ class besides the built-in support for tiled (MultiScaleImage) providers like BingRestMapProvider and OpenStreetMapProvider. You can either use it with single image for all zoom levels, or you can specify an image for every distinct zoom level.        
+RadMap provides support for single image provider through the `UriImageProvider` class besides the built-in support for tiled (MultiScaleImage) providers like BingRestMapProvider and OpenStreetMapProvider. You can either use it with single image for all zoom levels, or you can specify an image for every distinct zoom level.        
 
->tip To learn more about the UriImageProvider [read here]({%slug radmap-features-uriimageprovider%}).   
+To learn more about the UriImageProvider, check the [UriImageProvider]({%slug radmap-features-uriimageprovider%}) article.   
 
-## ArcGIS online services
+## ArcGIS Provider
 
-The [ArcGIS online services](http://www.esri.com/software/arcgis/arcgisonline/maps/maps-and-map-layers) can be used via the __ArcGisMapProvider__ class. Currently the ArcGIS map provider support 6 modes which can be set using Mode property:        
+RadMap exposes the functionality to display the [ArcGIS online services](http://www.esri.com/software/arcgis/arcgisonline/maps/maps-and-map-layers) via the `ArcGisMapProvider` class. 
 
-* Aerial
-* Physical
-* Shaded Relief
-* Street
-* Terrain
-* Topographic
+To learn more about the ArcGisMapProvider, check the [ArcGIS Online Map Provider]({%slug radmap-features-providers-arcgis%}) article.
 
-#### __[XAML] Example 7: Radmap with ArcGisMapProvider__
-{{region radmap-features-providers-8}}
-	<telerik:RadMap x:Name="radMap" ZoomLevel="1">
-		<telerik:RadMap.Provider>
-			<telerik:ArcGisMapProvider Mode="Physical" />
-		</telerik:RadMap.Provider>
-	</telerik:RadMap>
-{{endregion}}
+## Azure Maps Provider
 
-#### __[C#] Example 8: ArcGisMapProvider set in code__
-{{region radmap-features-providers-9}}
-	ArcGisMapProvider provider = new ArcGisMapProvider();
-	provider.Mode = ArcGisMapMode.Physical;
-	this.radMap.Provider = provider;
-{{endregion}}
+The RadMap control supports displaying tile data using the [Azure Map services](https://azure.microsoft.com/en-us/products/azure-maps/). This is done via the `AzureMapProvider` class and it provides support for both raster and vector sources.
 
-#### __[VB] Example 8: ArcGisMapProvider set in code__
-{{region radmap-features-providers-10}}
-	Dim provider As New ArcGisMapProvider ()
-	provider.Mode = ArcGisMapMode.Physical
-	Me.radMap.Provider = provider
-{{endregion}}
+For more information about the Azure Map services support, check the [Azure Map Provider]({%slug radmap-features-providers-azuremapprovider%}) article. 
 
-#### __Figure 3: Result from Examples 7 and 8__
-![Rad Map Features Providers 04](images/RadMap_Features_Providers_04.png)
+## MapBox Provider
+
+RadMap provides support for the [MapBox vector tile services](https://docs.mapbox.com/data/tilesets/guides/vector-tiles-introduction/) via the `MapBoxProvider` class.
+
+To learn more about how to use the MapBoxProvider, check the [MapBox Provider]({%slug radmap-features-mapboxprovider%}) article.
 
 ## See Also
- * [Empty provider]({%slug radmap-features-empty-provider%})
+
  * [BingRestMapProvider]({%slug radmap-features-providers-bing-rest-map%}) 
+ * [OpenStreetMapProvider]({%slug radmap-features-providers-osm-provider%})
+ * [Empty provider]({%slug radmap-features-empty-provider%})
  * [UriImageProvider]({%slug radmap-features-uriimageprovider%})
+ * [ArcGisMapProvider]({%slug radmap-features-providers-arcgis%})
+ * [AzureMapProvider]({%slug radmap-features-providers-azuremapprovider%})
+ * [MapBoxProvider]({%slug radmap-features-mapboxprovider%})


### PR DESCRIPTION
- Refactored the Providers Overview article and added information about missing providers
- Added a new article for the OSM provider
- Addea d section for each provider that uses third-party tile data for the attribution copyright label