### PR TITLE
Update installing-license-to-ci-services.md

### DIFF
--- a/getting-started/licensing/installing-license-to-ci-services.md
+++ b/getting-started/licensing/installing-license-to-ci-services.md
@@ -51,7 +51,7 @@ The recommended approach for providing your license key to the `Telerik.Licensin
 	#### __[YML]__
 	{{region installing-license-to-ci-services-0}}
 		env:
-			TELERIK_LICENSE: ${{ secrets.TELERIK_LICENSE }}
+			TELERIK_LICENSE: ${{ "{{ secrets.TELERIK_LICENSE }}" }}
 	{{endregion}}
 
 ## See Also  


### PR DESCRIPTION
Fix broken GH secret variable

In the current state, we're using:

`TELERIK_LICENSE: ${{ secrets.TELERIK_LICENSE }}`

However, the variable is removed when the docs are rendered. Here's the result:
![image](https://github.com/user-attachments/assets/7ff51c50-0ad3-4b7e-98b8-6ac704ccaf34)

To solve this, there needs to be a set of quotes wrapped around the intended content:

`TELERIK_LICENSE: ${{ "{{ secrets.TELERIK_LICENSE }}" }}`