### PR TITLE
Fix typo in RadChart data binding

### DIFF
--- a/controls/radchart/features/data-binding.md
+++ b/controls/radchart/features/data-binding.md
@@ -16,7 +16,7 @@ position: 1
 
 __RadChart__ supports data binding to various data sources and services. Moreover, __RadChart__ can be used in two modes:
 
-* [Automatic Series Mappings]({%slug radchart-populating-with-data-data-binding-with-automatic-series-binding%}) - simply set __ReadChart.ItemsSource__ and __RadChart__ will automatically create the needed series mapping. Use automatic data series mapping when you have simple data. 
+* [Automatic Series Mappings]({%slug radchart-populating-with-data-data-binding-with-automatic-series-binding%}) - simply set __RadChart.ItemsSource__ and __RadChart__ will automatically create the needed series mapping. Use automatic data series mapping when you have simple data. 
 
 
 * [Manual Series Mapping]({%slug radchart-populating-with-data-data-binding-with-manual-series-mapping%}) - use manual series mapping for more complex business objects or when you want more control.


### PR DESCRIPTION
Text should read `RadChart` instead of `ReadChart`.