### PR TITLE
VirtualGrid custom editor and edit lifecycle

### DIFF
--- a/controls/radvirtualgrid/features/editing.md
+++ b/controls/radvirtualgrid/features/editing.md
@@ -8,11 +8,25 @@ published: True
 position: 0
 ---
 
-# Editing 
+# Editing
 
-> By default, the __CanUserEdit__ property of __RadVirtualGrid__ is set to __True__, thus the editing mechanism is enabled. In order to disable it, its value needs to be set to __False__.
+> By default, the __CanUserEdit__ property of __RadVirtualGrid__ is set to __True__, thus the editing mechanism is enabled. In order to disable it, set its value to __False__.
 
-As __RadVirtualGrid__ does not utilize data binding for populating and managing its data, it does not provide a default editor. Instead, when the user double clicks to enter edit mode, the __EditorNeeded__ event is raised. This means that by default there won't be editor visulized until you create it in the event handler.
+__RadVirtualGrid__ uses one of two editing paths:
+
+* Without a __DataProvider__, handle __CellValueNeeded__, __EditorNeeded__, __EditorValueChanged__, and __CellEditEnded__ yourself. The control does not persist edited values in your data source automatically.
+
+* With a __DataProvider__, the provider creates the default editor, supplies cell values, determines whether a column is read-only, and handles the edit lifecycle. The default __DataProvider__ automatically writes committed values to its source and updates the grid.
+
+The editor lifecycle is:
+
+1. The user enters edit mode through an edit trigger or a call to __BeginEdit__.
+2. __EditorNeeded__ is raised. Create an editor, assign it to __Editor__, and assign the editor dependency property to __EditorProperty__.
+3. The editor changes its dependency property. __EditorValueChanged__ receives the current value.
+4. The edit ends through __CommitEdit__, __CancelEdit__, or the configured __ActionOnLostFocus__ behavior. __CellEditEnded__ receives the final value and an __EditAction__.
+5. For a committed edit, persist the value and call __PushCellValue__ when you manage the data source directly. A __DataProvider__ does this automatically when __ShouldPushEditValueToGrid__ is __True__.
+
+* [Editing paths](#editing-paths)
 
 * [Events](#events)
 
@@ -22,9 +36,94 @@ As __RadVirtualGrid__ does not utilize data binding for populating and managing 
 
 * [Action on LostFocus](#action-on-lostfocus)
 
+## Editing paths
+
+### Direct event handling
+
+Use direct event handling when you populate the grid through __InitialRowCount__ and __InitialColumnCount__ and keep the data outside a __DataProvider__. Handle __CellValueNeeded__ to display values, create the editor in __EditorNeeded__, and persist the value in __CellEditEnded__.
+
+The following example uses a __TextBox__ for every editable cell. Replace the `SaveValue` implementation with the code that updates your data source.
+
+```C#
+using System.Windows.Controls;
+using Telerik.Windows.Controls;
+using Telerik.Windows.Controls.VirtualGrid;
+
+private void VirtualGrid_CellValueNeeded(object sender, CellValueEventArgs e)
+{
+    e.Value = this.GetValue(e.RowIndex, e.ColumnIndex);
+}
+
+private void VirtualGrid_EditorNeeded(object sender, EditorNeededEventArgs e)
+{
+    var editor = new TextBox
+    {
+        Text = e.TextInput ?? this.GetValue(e.RowIndex, e.ColumnIndex)?.ToString()
+    };
+
+    e.Editor = editor;
+    e.EditorProperty = TextBox.TextProperty;
+}
+
+private void VirtualGrid_CellEditEnded(object sender, CellEditEndedEventArgs e)
+{
+    if (e.EditAction != VirtualGridEditAction.Commit)
+    {
+        return;
+    }
+
+    this.SaveValue(e.RowIndex, e.ColumnIndex, e.Value);
+    this.VirtualGrid.PushCellValue(e.RowIndex, e.ColumnIndex, e.Value);
+}
+```
+
+The __PushCellValue__ call updates the value that __RadVirtualGrid__ renders. It does not replace persistence in the underlying data source, so call both operations after a committed edit.
+
+### DataProvider editing
+
+Use a __DataProvider__ when the grid should read and write values through an item collection. The default provider creates a __TextBox__ editor, uses item properties to determine the editor value, and treats read-only item properties as non-editable.
+
+The provider's __ShouldPushEditValueToGrid__ property returns __True__ by default. On a committed edit, __RadVirtualGrid__ calls __PushCellValueToSource__ and __PushCellValue__. Override this property when your provider owns synchronization and must handle the source and grid update itself.
+
+The provider also receives __OnCellValueNeeded__, __OnEditorNeeded__, __OnEditorValueChanged__, and __OnCellEditEnded__ calls. When a __DataProvider__ is assigned, the corresponding public editing events are not raised by __RadVirtualGrid__; override the provider methods instead.
+
+```C#
+using System.Collections;
+using System.Windows;
+using System.Windows.Controls;
+using Telerik.Windows.Controls.VirtualGrid;
+
+public class ProductDataProvider : DataProvider
+{
+    public ProductDataProvider(IEnumerable source)
+        : base(source)
+    {
+    }
+
+    protected override void CreateEditor(out FrameworkElement editor, out DependencyProperty editorProperty, object propertyValue, int columnIndex)
+    {
+        editor = new TextBox
+        {
+            Text = propertyValue?.ToString()
+        };
+        editorProperty = TextBox.TextProperty;
+    }
+
+    protected internal override void OnCellEditEnded(CellEditEndedEventArgs e)
+    {
+        if (e.EditAction == VirtualGridEditAction.Commit)
+        {
+            // Persist here only when the provider owns custom conversion or storage.
+        }
+    }
+}
+```
+
+If the custom provider does not override __ShouldPushEditValueToGrid__, the base provider still converts the value to the item property type, writes it through the property descriptor, and refreshes the grid after a commit. Do not persist a cancelled value: __CellEditEndedEventArgs.EditAction__ is __Cancel__ when the edit is cancelled.
+
 ## Events
 
->important The editing events will not be raised when the __DataProvider__ mechanism is used for populating the data of __RadVirtualGrid__. More information can be found in the [Getting Started]({%slug virtualgrid-getting-started2%}) topic.
+>important The public editing events are not raised when the __DataProvider__ mechanism is used for populating the data of __RadVirtualGrid__. Override the corresponding __DataProvider__ methods instead. More information can be found in the [Custom DataProvider]({%slug virtualgrid-custom-dataprovider%}) topic.
 
 ### EditorNeeded
 
@@ -38,7 +137,7 @@ Through this event a custom editor for handling the editing operation can be def
 
 * __EditorProperty__: The editor's dependency property that is to be edited
 
-* __TextInput__: Gets the string containing the entered text when the __TextInput__ event occurs.The value of the property will be equal to the key with which enter mode is entered.
+* __TextInput__: Gets the string containing the entered text when the __TextInput__ edit trigger starts an edit. Use this value when you want the first typed character to replace the original cell value.
 
 > The property of the editor that is being edited needs to be set manually as well.
 
@@ -50,7 +149,7 @@ __Example 1: Handling the EditorNeeded event__
             TextBox tb = new TextBox();
 
             e.Editor = tb;
-            tb.Text = String.Format("{0}.{1}", e.RowIndex, e.ColumnIndex);
+            tb.Text = e.TextInput;
             e.EditorProperty = TextBox.TextProperty;
         }
 ```
@@ -59,13 +158,13 @@ __Example 1: Handling the EditorNeeded event__
 
 ### EditorValueChanged
 
-This event is triggered each time the underlying property value that is edited has been changed. Its event arguments provide the following information. 
+This event is triggered each time the editor dependency property changes. With a __DataProvider__, override __DataProvider.OnEditorValueChanged__ instead of handling this public event.
 
 * __ColumnIndex__: Provides information regarding the column index of the editor
 
 * __RowIndex__: Provides information regarding the row index of the editor
 
-* __Value__: Provides information regarding the user input.
+* __Value__: Provides the current editor value.
 
 __Example 2: Handling the EditorValueChanged event__  
 ```C#
@@ -78,19 +177,25 @@ __Example 2: Handling the EditorValueChanged event__
 
 ### CellEditEnded
 
-The event is raised when the user ends editing the cell by setting the focus to another element.  This is the mechanism through which the data modified through the UI can be synchronized with the underlying data source, as updating the data source will be needed only once when the edit of the cell has ended. The properties of the event arguments are listed below.
+The event is raised when the edit ends. The event can result from __CommitEdit__, __CancelEdit__, or __ActionOnLostFocus__. With a __DataProvider__, override __DataProvider.OnCellEditEnded__ instead of handling this public event.
 
 * __ColumnIndex__: Provides information regarding the column index of the editor
 
 * __RowIndex__: Provides information regarding the row index of the editor
 
-* __Value__: Provides information regarding the user input.
+* __Value__: Provides the current or final editor value.
+
+* __EditAction__: Indicates whether the edit was committed through __VirtualGridEditAction.Commit__ or cancelled through __VirtualGridEditAction.Cancel__.
 
 __Example 3: Handling the CellEditEnded event__  
 ```C#
 	   private void VirtualGrid_CellEditEnded_1(object sender, CellEditEndedEventArgs e)
         {
-
+            if (e.EditAction == VirtualGridEditAction.Commit)
+            {
+                this.SaveValue(e.RowIndex, e.ColumnIndex, e.Value);
+                this.VirtualGrid.PushCellValue(e.RowIndex, e.ColumnIndex, e.Value);
+            }
         }
 ```
 
@@ -116,16 +221,20 @@ Commits the current edit and exits edit mode.
 
 ### PushCellValue
 
-When an edit is committed, the new property value needs to be manually pushed to the underlying source and to __RadVirtualGrid__ as well. The control exposes the __PushCellValue__ method for updating the UI. The method can be used in conjunction with the aforementioned __CellEditEnded__ event handler. It accepts the following parameters. 
+When an edit is committed through direct event handling, persist the new value in the underlying source and call __PushCellValue__ to update __RadVirtualGrid__. The method only updates the value rendered by the control; it does not write to your source. A __DataProvider__ calls the source and grid update methods automatically when __ShouldPushEditValueToGrid__ is __True__.
 
 * __PushCellValue(int rowIndex, int columnIndex, object value)__
 
-__Example 2: Updating RadVirtualGrid with the modified data__  	
+__Example 4: Updating RadVirtualGrid with the modified data__  	
 ```C#
 	private void VirtualGrid_CellEditEnded(object sender, 
-            Telerik.Windows.Controls.VirtualGrid.CellValueEventArgs e)
+            Telerik.Windows.Controls.VirtualGrid.CellEditEndedEventArgs e)
         {
-            this.VirtualGrid.PushCellValue(e.RowIndex, e.ColumnIndex, e.Value);
+            if (e.EditAction == VirtualGridEditAction.Commit)
+            {
+                this.SaveValue(e.RowIndex, e.ColumnIndex, e.Value);
+                this.VirtualGrid.PushCellValue(e.RowIndex, e.ColumnIndex, e.Value);
+            }
         }
 ```
 

--- a/controls/radvirtualgrid/features/editing.md
+++ b/controls/radvirtualgrid/features/editing.md
@@ -36,9 +36,9 @@ The editor lifecycle is:
 
 * [Action on LostFocus](#action-on-lostfocus)
 
-## Editing paths
+## Editing Paths
 
-### Direct event handling
+### Direct Event Handling
 
 Use direct event handling when you populate the grid through __InitialRowCount__ and __InitialColumnCount__ and keep the data outside a __DataProvider__. Handle __CellValueNeeded__ to display values, create the editor in __EditorNeeded__, and persist the value in __CellEditEnded__.
 


### PR DESCRIPTION
Please **review the changes carefully** and **validate their correctness**! Share any feedback you may have!

VirtualGrid custom editor and edit lifecycle
Priority: High
Confidence: 9

Missing Functionality:
`RadVirtualGrid` exposes `EditorNeeded`, `EditorValueChanged`, `CellEditEnded`, `CellValueNeeded`, and related push-value behavior for implementing custom editors and committing edits.

Evidence Found in Code:
- `Source/Controls/VirtualGrid/Code/RadVirtualGrid.cs`
- `Source/Controls/VirtualGrid/Code/Editing/`
- `Source/Controls/VirtualGrid/Code/CellValueEventArgs.cs`
- Existing articles: `controls/radvirtualgrid/features/editing.md` and `controls/radvirtualgrid/features/custom-dataprovider.md`

Current Documentation Status:
Partial. The custom data-provider article lists override points and the control has a custom-cell-content article, but the complete event order and custom-editor implementation are not sufficiently documented as a user workflow.

Remediation Action:
- Action: Update existing article
- Target file: `controls/radvirtualgrid/features/editing.md`
- Details: Document editor creation, value propagation, `ShouldPushEditValueToGrid`, commit/cancel behavior, event order, read-only decisions, and a complete custom editor example.

Recommended Documentation:
Add a lifecycle diagram or ordered list and show both direct event handling and a custom `DataProvider` implementation.

Business/User Impact:
Incorrect edit propagation can display a changed value without updating the underlying data source, causing data loss or confusing UI state.

Confidence Score: 9/10