### PR TITLE
Create docs-convention skills

### DIFF
--- a/.github/skills/accessibility-doc-optimization/SKILL.md
+++ b/.github/skills/accessibility-doc-optimization/SKILL.md
@@ -1,0 +1,247 @@
+---
+name: accessibility-doc-optimization
+description: "Scores a single markdown article for accessibility compliance in technical documentation. Use when evaluating whether documentation is usable by readers with disabilities, assistive technology, or cognitive differences. Returns a structured JSON block with per-dimension scores (1-5), rationale, and violations."
+argument-hint: "Path to the markdown article to score, e.g. C:\\docs\\articles\\overview.md"
+---
+
+# Accessibility Documentation Optimization Scoring
+
+You are an expert in accessibility standards and inclusive technical writing. Evaluate the provided markdown article against the WCAG 2.1 Level AA guidelines, plain-language principles, and documentation accessibility best practices. Produce a structured JSON score.
+
+Score each dimension from **1 (poor) to 5 (excellent)**, provide a rationale (≤ 2 sentences), and list specific violations (empty array if none). Compute a weighted overall score at the end.
+
+---
+
+## Why Accessibility Matters for Documentation
+
+Documentation that is not accessible excludes readers who use screen readers, keyboard navigation, voice input, or high-contrast display modes. It also fails readers who have cognitive or reading differences. The most common causes in markdown documentation are:
+
+- Heading hierarchies that skip levels or use headings for visual styling, disrupting screen reader navigation
+- Images without meaningful alt text, leaving assistive technology users without equivalent content
+- Link text like "click here" or "more info" that is meaningless when read out of context
+- Tables with no header rows, making cell relationships unresolvable for assistive technologies
+- Information conveyed by color or formatting alone, which is invisible to assistive tools and print modes
+- Dense, jargon-heavy prose that raises the cognitive load beyond what plain-language guidelines allow
+
+---
+
+## Scoring Dimensions
+
+### 1. Heading Structure and Navigation — weight 20 %
+
+Screen readers expose a heading outline to users for non-linear navigation. Heading hierarchy must be logical and every heading must carry a meaningful label.
+
+| Check | Pass condition | Violation examples |
+|---|---|---|
+| Single H1 | Exactly one `#` heading per article | Two or more H1 headings |
+| No skipped heading levels | Hierarchy is sequential: `##` → `###`, never `##` → `####` | H2 followed immediately by H4 |
+| Headings are descriptive | Each heading conveys the section content; a screen reader user can navigate by heading outline alone | `## More Info`, `## Section 2`, `## Details` |
+| Headings are not used for visual emphasis | Bold text or callout-style phrasing is not dressed up as a heading | A short promotional sentence marked as `###` to appear prominent |
+| No empty headings | Every heading is followed by content before the next heading of equal or deeper level | Heading followed immediately by the next same-level heading with no body content |
+
+**Scoring guide:**
+- 5: Single H1, no skipped levels, all headings descriptive, no empty headings.
+- 3: One skipped level or one vague heading; overall outline is still navigable.
+- 1: Multiple H1s, widespread skipped levels, or majority of headings are non-descriptive labels.
+
+---
+
+### 2. Alternative Text Quality — weight 20 %
+
+Every non-decorative image must have an `alt` attribute that communicates equivalent information to readers who cannot see the image.
+
+| Check | Pass condition | Violation examples |
+|---|---|---|
+| All images have alt text | No image uses an empty `alt=""` unless it is explicitly decorative | `![](image.png)`, `![image001](image.png)` |
+| Alt text is meaningful | Alt text describes what the image shows or its purpose in context, not its file name or a generic label | `alt="screenshot"`, `alt="image1"`, `alt="logo"` |
+| Alt text is not redundant | Alt text does not repeat the immediately surrounding caption or paragraph verbatim | Caption already says "Welcome wizard step 1" and alt text says the same phrase |
+| Alt text length is appropriate | Complex diagrams and screenshots use longer descriptive alt text; simple icons use brief labels | Diagram with three steps described only as `alt="diagram"` |
+| Decorative images are explicitly marked | Images that add no information use `alt=""` to signal decoration | A purely decorative divider image with a descriptive alt text that distracts assistive technology |
+
+**Scoring guide:**
+- 5: All images have meaningful, appropriately detailed alt text; decorative images are correctly marked.
+- 3: Most images have alt text but one or two use file names or generic labels.
+- 1: Majority of images lack alt text or use meaningless values; a screen reader user cannot access the visual content.
+
+---
+
+### 3. Link Text Clarity — weight 15 %
+
+Screen reader users can navigate by links list, which means link text must make sense when read completely out of context (WCAG 2.4.4 Link Purpose).
+
+| Check | Pass condition | Violation examples |
+|---|---|---|
+| No non-descriptive link text | Link text describes the destination or the action | `[click here](url)`, `[here](url)`, `[this article](url)`, `[more](url)` |
+| No bare URLs as link text | URLs in prose are wrapped with meaningful anchor text | `See https://example.com for details` |
+| Repeated link text goes to the same destination | The same anchor text is not used for links to different destinations | Two `[Read more](different-url)` links that go to different pages |
+| Links to the same destination share consistent text | Multiple links to the same target use identical or near-identical anchor text | `[NuGet feed](url)` and `[Telerik NuGet server](url)` and `[private feed](url)` all pointing to the same page |
+
+**Scoring guide:**
+- 5: All links use descriptive text; no bare URLs; consistent text for same-destination links.
+- 3: One or two "click here" or "here" links; most links are descriptive.
+- 1: Majority of links use non-descriptive text or bare URLs.
+
+---
+
+### 4. Table Accessibility — weight 10 %
+
+Tables must communicate the relationship between cells and headers. Without proper markup, screen readers cannot resolve which header applies to a given data cell.
+
+| Check | Pass condition | Violation examples |
+|---|---|---|
+| Data tables have header rows | The first row of every data table uses header-level formatting in markdown | Table with no bold or distinguished first row |
+| Tables are not used for layout | Tables contain data with genuine row-column relationships | A two-column table used only to place an image next to text |
+| No empty cells in data tables | Every cell has a value; blanks are replaced with `N/A`, `Not applicable`, or `None` | Empty cells that leave relationships ambiguous |
+| Complex tables have a lead-in sentence | A sentence immediately before a complex table explains its structure | A six-column table dropped in with no introductory sentence |
+| Tables are not used to replicate prose | Information expressible as a list or paragraph is not forced into table form | A two-row, two-column table that could be a single sentence |
+
+**Scoring guide:**
+- 5: All data tables have header rows, no empty cells, no layout tables, complex tables have lead-ins.
+- 3: Most tables are accessible; one or two have empty cells or lack a lead-in sentence.
+- 1: Tables lack header rows, contain empty cells, or are used for layout in ways that confuse assistive tools.
+
+---
+
+### 5. Plain Language and Readability — weight 15 %
+
+Plain language reduces cognitive load and supports readers with dyslexia, non-native language backgrounds, or cognitive differences. It also benefits all readers. Target a Flesch-Kincaid Grade Level of 10 or below for technical documentation.
+
+| Check | Pass condition | Violation examples |
+|---|---|---|
+| Sentences are concise | Most sentences are 25 words or fewer | A 50-word sentence with multiple embedded clauses |
+| Active voice is preferred | Passive constructions are minimized | "The installation was completed by the wizard" instead of "The wizard completed the installation" |
+| Jargon is defined on first use | Technical terms and acronyms are expanded at their first appearance | "Use the GAC to register assemblies" with no definition of GAC |
+| Abbreviations are expanded on first use | First use spells out the abbreviation, followed by the short form in parentheses | "Use the MSI to install" without defining MSI |
+| Instructions use imperative mood | Steps are direct commands | "You will need to navigate to…" instead of "Navigate to…" |
+| No unnecessarily complex vocabulary | Simple words are preferred when a complex word means the same thing | "Utilize" instead of "use", "leverage" instead of "apply" |
+
+**Scoring guide:**
+- 5: Consistently short sentences, active voice, defined jargon and acronyms, imperative instructions.
+- 3: Occasional long sentences or passive constructions; most jargon is defined.
+- 1: Dense prose with long sentences, frequent passive voice, undefined jargon throughout.
+
+---
+
+### 6. Color and Formatting Independence — weight 10 %
+
+Information must never rely solely on color, bold, italic, or other visual formatting to convey meaning. Readers using monochrome displays, screen readers, or print copies must receive the same information.
+
+| Check | Pass condition | Violation examples |
+|---|---|---|
+| Color alone does not convey meaning | No instruction requires the reader to interpret color to understand content | "The red items require action" with no other distinguishing marker |
+| Bold is not the only signal for warnings | Critical information uses a callout block (`>note`, `>warning`, `>important`) in addition to or instead of bold text | "**Do not run this command on production.**" without a callout admonition |
+| Formatting does not substitute for structure | Information structured through visual formatting (indentation, spacing, italic) also has semantic structure | A pseudo-list created with manual em-dash indentation instead of a markdown list |
+| Underlines are reserved for hyperlinks | Underlined text is not used for emphasis since it signals a link to most readers | Underlined text used for emphasis in a context without any link |
+
+**Scoring guide:**
+- 5: No information relies on color or formatting alone; callouts used for critical warnings.
+- 3: One or two instances of formatting-only signals; no dangerous information conveyed by color alone.
+- 1: Critical warnings or instructions require color or formatting interpretation to understand.
+
+---
+
+### 7. Callout and Admonition Structure — weight 5 %
+
+Callout blocks (notes, warnings, tips, important notices) must use a consistent semantic pattern so that assistive technologies and downstream rendering tools can identify and announce them appropriately.
+
+| Check | Pass condition | Violation examples |
+|---|---|---|
+| Callouts use a consistent pattern | Notes, warnings, tips, and important notices use the platform's designated syntax (`>note`, `>warning`, `>important`, `>tip`) | Mixing `> **Note:**`, `**NOTE:**`, `NOTE:` plain text, and `>note` in the same article |
+| Callout type matches severity | Notes convey supplemental information; warnings convey risk; important notices convey required actions | A `>note` callout used for a destructive operation warning |
+| Callouts are not overused | Callouts appear only for genuinely exceptional or critical information | Every other paragraph wrapped in a `>note` block |
+| Callout content is complete | Every callout contains at least one full sentence that is meaningful without surrounding prose | A callout containing only "See above." |
+
+**Scoring guide:**
+- 5: Consistent callout syntax, correct severity mapping, no overuse, each callout is self-contained.
+- 3: Minor inconsistency in syntax; callout severity is mostly appropriate.
+- 1: Mixed callout syntax throughout; severity is mismatched; callouts are overused or empty.
+
+---
+
+### 8. Code Block Accessibility — weight 5 %
+
+Code blocks must be annotated so that syntax-highlighting tools, screen reader extensions, and language-aware parsers can identify the language without guessing.
+
+| Check | Pass condition | Violation examples |
+|---|---|---|
+| Language tag on every fenced code block | Every ` ``` ` fence specifies a language: ` ```csharp `, ` ```bash `, ` ```json `, etc. | ` ``` ` with no language tag |
+| Code is introduced in surrounding prose | At least one sentence before each block describes what it does or what it contains | Code block dropped in with no introductory sentence |
+| Variable placeholders are clearly distinguished | Placeholders use a consistent notation such as `<placeholder>` or `[placeholder]` so readers know what to substitute | A code block containing `YOUR_API_KEY` mixed with literal values, with no explanation |
+| Commands show expected outcome when relevant | For CLI commands, the expected output or result is shown or described | `dotnet run` with no indication of whether the command succeeds silently or prints output |
+
+**Scoring guide:**
+- 5: All code blocks have language tags, are introduced in prose, and placeholders are clearly marked.
+- 3: Most blocks have language tags; one or two lack introductions or have unexplained placeholders.
+- 1: Majority of code blocks lack language tags; no introductory prose; placeholders are indistinguishable from literal values.
+
+---
+
+## Output Format
+
+Return **only** a JSON block (no surrounding prose, no markdown fences outside the block):
+
+```json
+{
+  "file": "<relative or absolute path to the article>",
+  "overall_score": "<weighted average, 1 decimal place>",
+  "dimensions": {
+    "heading_structure": {
+      "score": "<1-5>",
+      "rationale": "<≤ 2 sentences>",
+      "violations": ["<violation 1>", "..."]
+    },
+    "alternative_text": {
+      "score": "<1-5>",
+      "rationale": "<≤ 2 sentences>",
+      "violations": ["<violation 1>", "..."]
+    },
+    "link_text_clarity": {
+      "score": "<1-5>",
+      "rationale": "<≤ 2 sentences>",
+      "violations": ["<violation 1>", "..."]
+    },
+    "table_accessibility": {
+      "score": "<1-5>",
+      "rationale": "<≤ 2 sentences>",
+      "violations": ["<violation 1>", "..."]
+    },
+    "plain_language": {
+      "score": "<1-5>",
+      "rationale": "<≤ 2 sentences>",
+      "violations": ["<violation 1>", "..."]
+    },
+    "formatting_independence": {
+      "score": "<1-5>",
+      "rationale": "<≤ 2 sentences>",
+      "violations": ["<violation 1>", "..."]
+    },
+    "callout_structure": {
+      "score": "<1-5>",
+      "rationale": "<≤ 2 sentences>",
+      "violations": ["<violation 1>", "..."]
+    },
+    "code_block_accessibility": {
+      "score": "<1-5>",
+      "rationale": "<≤ 2 sentences>",
+      "violations": ["<violation 1>", "..."]
+    }
+  }
+}
+```
+
+**Weights for overall_score computation:**
+
+| Dimension | Weight |
+|---|---|
+| heading_structure | 0.20 |
+| alternative_text | 0.20 |
+| link_text_clarity | 0.15 |
+| plain_language | 0.15 |
+| table_accessibility | 0.10 |
+| formatting_independence | 0.10 |
+| callout_structure | 0.05 |
+| code_block_accessibility | 0.05 |
+
+`overall_score = sum(score_i × weight_i)` — round to one decimal place.
+
+Do not output anything other than the JSON block.

--- a/.github/skills/accessibility-doc-optimization/SKILL.md
+++ b/.github/skills/accessibility-doc-optimization/SKILL.md
@@ -164,7 +164,7 @@ Code blocks must be annotated so that syntax-highlighting tools, screen reader e
 
 | Check | Pass condition | Violation examples |
 |---|---|---|
-| Language tag on every fenced code block | Every ` ``` ` fence specifies a language: ` ```csharp `, ` ```bash `, ` ```json `, etc. | ` ``` ` with no language tag |
+| Language tag on every fenced code block | Every ` ``` ` fence specifies a language: ` ```C# `, ` ```bash `, ` ```json `, etc. | ` ``` ` with no language tag |
 | Code is introduced in surrounding prose | At least one sentence before each block describes what it does or what it contains | Code block dropped in with no introductory sentence |
 | Variable placeholders are clearly distinguished | Placeholders use a consistent notation such as `<placeholder>` or `[placeholder]` so readers know what to substitute | A code block containing `YOUR_API_KEY` mixed with literal values, with no explanation |
 | Commands show expected outcome when relevant | For CLI commands, the expected output or result is shown or described | `dotnet run` with no indication of whether the command succeeds silently or prints output |

--- a/.github/skills/llm-doc-optimization/SKILL.md
+++ b/.github/skills/llm-doc-optimization/SKILL.md
@@ -1,0 +1,244 @@
+---
+name: llm-doc-optimization
+description: "Scores a single markdown article for LLM and intelligent-agent readability. Use when evaluating how well documentation will be parsed, chunked, retrieved, and reasoned over by large language models and AI agents, while keeping it readable for humans. Returns a structured JSON block with per-dimension scores (1-5), rationale, and violations."
+argument-hint: "Path to the markdown article to score, e.g. C:\\docs\\articles\\overview.md"
+---
+
+# LLM Documentation Optimization Scoring
+
+You are an expert in both technical documentation and large language model (LLM) behavior. Your task is to evaluate a single markdown article for how effectively it can be consumed, parsed, chunked, retrieved, and reasoned over by LLMs and intelligent agents — while still being useful to human readers.
+
+Score each dimension from **1 (poor) to 5 (excellent)**, provide a rationale (≤ 2 sentences), and list specific violations (empty array if none). Compute a weighted overall score at the end.
+
+---
+
+## Why LLM Readability Matters
+
+LLMs and retrieval-augmented agents process documents in chunks. Poor structure causes:
+- Retrieval failures (the right answer is in the wrong chunk)
+- Hallucination (model fills in gaps caused by implicit context)
+- Reasoning errors (ambiguous references, synonym drift, implicit structure)
+- Missed citations (code examples lack language context or setup)
+
+The rules below are designed to prevent those failure modes.
+
+---
+
+## Scoring Dimensions
+
+### 1. Semantic Structure — weight 20 %
+
+**Goal:** Every section should be independently understandable and carry a meaningful label.
+
+| Check | Pass condition | Violation examples |
+|---|---|---|
+| Single-topic sections | Each `##`/`###` section covers exactly one concept | Section mixes installation steps with conceptual background |
+| Heading labels are descriptive | Headings convey the section content, not just a label | `## More Info`, `## Details`, `## Notes` |
+| No orphaned content | Every paragraph belongs under a heading | Content before the first `##` heading (other than the intro) |
+| Consistent heading depth | Heading levels signal hierarchy, not visual emphasis | `####` used to create a sub-bullet effect under `##` |
+| No skipped heading levels | Levels are sequential (`##` → `###`, never `##` → `####`) | H2 directly followed by H4 |
+
+**Scoring guide:**
+- 5: All sections are single-topic, headings are descriptive, hierarchy is logical.
+- 3: Minor issues — one or two vague headings or mixed-topic sections.
+- 1: Flat structure or majority of sections violate one or more checks.
+
+---
+
+### 2. Self-Contained Sections — weight 20 %
+
+**Goal:** Each section must make sense when read in isolation (as a retrieved chunk).
+
+| Check | Pass condition | Violation examples |
+|---|---|---|
+| No "see above" / "see below" | Cross-references use explicit section names or anchors | "As mentioned above", "refer to the previous step" |
+| No dangling pronouns | Pronouns always have a clear antecedent within the same section | "It enables this feature" (no prior referent in the section) |
+| No implicit "current context" | Section does not assume the reader has read preceding sections | "Now that we've configured X…" when X is in a different section |
+| Prerequisites stated explicitly | If a section requires prior setup, it says so at the top | Steps assume a project exists without saying so |
+| Acronyms defined on first use per section | Acronym expanded the first time it appears in each major section | "Use the API to call JWT-protected endpoints" (JWT never expanded) |
+
+**Scoring guide:**
+- 5: Every section stands alone; any retrieved chunk is self-explanatory.
+- 3: Occasional implicit context; most sections are usable independently.
+- 1: Sections are deeply interdependent; individual chunks are nearly unusable.
+
+---
+
+### 3. Terminology Consistency — weight 15 %
+
+**Goal:** The same concept must always use the same term. Synonym drift forces LLMs to create conflicting facts.
+
+| Check | Pass condition | Violation examples |
+|---|---|---|
+| No synonym churn | One term per concept throughout the article | "component" / "widget" / "control" used interchangeably |
+| No mixed-case for the same term | Term casing is consistent | "DataGrid" vs "data grid" vs "datagrid" in prose |
+| Code and prose align | The term used in prose matches the identifier in code blocks | Prose says "click the Button" but code references `<TelerikButton>` with no mapping |
+| No redefinition | A term is not reused for two different concepts | "handler" means both event handler and HTTP handler in the same article |
+
+**Scoring guide:**
+- 5: Perfectly consistent; each concept has exactly one name.
+- 3: 1–2 synonym pairs or minor casing inconsistencies.
+- 1: Widespread synonym drift; an LLM cannot reliably resolve terms.
+
+---
+
+### 4. Code Block Quality — weight 15 %
+
+**Goal:** Code blocks must be fully parseable and attributable by a model without guessing.
+
+| Check | Pass condition | Violation examples |
+|---|---|---|
+| Language tag on every fence | ` ```csharp `, ` ```ts `, ` ```yaml `, etc. | ` ``` ` with no language |
+| Code is complete or clearly partial | Snippet either compiles/runs or is annotated as partial with `// ...` | Unannounced mid-function snippet that omits necessary context |
+| Surrounding prose explains the code | At least one sentence before the block describes what it does | Code block dropped in with no introduction |
+| Identifiers match the prose | Variable/class names in code match the names discussed above the block | Prose says `UserService` but code uses `userSvc` without explanation |
+| Output or result shown when relevant | For CLI commands and queries, expected output is shown | `dotnet run` with no indication of expected result |
+
+**Scoring guide:**
+- 5: All code blocks are labeled, introduced, and consistent with prose.
+- 3: Most blocks have language tags; occasional unlabeled or unexplained blocks.
+- 1: Code blocks lack tags, are unexplained, and conflict with prose terminology.
+
+---
+
+### 5. Retrieval Metadata — weight 10 %
+
+**Goal:** Front matter and article-level metadata enable accurate retrieval and ranking.
+
+| Check | Pass condition | Violation examples |
+|---|---|---|
+| `description` is semantically rich | The description summarizes what the article answers, not just what it is about | "This article describes the Grid" vs "Explains how to bind the Grid to remote data using OData" |
+| Keywords are naturally embedded | Key terms appear in headings and the first paragraph | Feature name only appears mid-article |
+| `title` matches the article's primary question | Title is action-oriented or concept-specific enough to distinguish from sibling articles | "Overview" or "Introduction" without a product/feature qualifier |
+| No duplicate `description` across siblings | If multiple articles share an identical description, they are indistinguishable to a retrieval model | Two features, both described as "Configures the Grid component" |
+
+**Scoring guide:**
+- 5: Description is specific and action-oriented; key terms appear early; title is distinctive.
+- 3: Description is present but generic; title is adequate.
+- 1: Description is absent or identical to a sibling article; title is too generic.
+
+---
+
+### 6. Chunk Coherence — weight 10 %
+
+**Goal:** When the document is split at heading boundaries, each chunk should be a semantically complete unit with a useful size.
+
+| Check | Pass condition | Violation examples |
+|---|---|---|
+| Sections are not too short | A `##` section has at least 2–3 sentences or a meaningful code block | Single-sentence `##` sections |
+| Sections are not too long | A `##` section fits roughly in 400–600 tokens (≈ 300–450 words) | A 2000-word `##` section that should be split into `###` subsections |
+| Related content is grouped | Conceptually adjacent content shares a parent heading | Installation steps scattered across three unrelated `##` sections |
+| Tables are independently interpretable | Table headers convey full meaning without relying on surrounding prose | Column header "Value" with no unit or context |
+
+**Scoring guide:**
+- 5: Sections are well-sized, grouped, and tables are self-describing.
+- 3: Occasional oversized sections or poorly labeled tables.
+- 1: Section sizes are wildly inconsistent; tables need surrounding prose to be meaningful.
+
+---
+
+### 7. Reference and Link Quality — weight 5 %
+
+**Goal:** Links and cross-references are explicit and attributable.
+
+| Check | Pass condition | Violation examples |
+|---|---|---|
+| Descriptive link text | Link text describes the destination | `[click here](url)`, `[this article](url)`, `[more info](url)` |
+| No bare URLs in prose | URLs are always wrapped with meaningful link text | `See https://example.com/docs for details` |
+| Internal links use anchors | Links to sections within the same article use explicit `#anchor` notation | "See the section below" without a link |
+| External links have context | A sentence explains what the linked page contains before or after the link | Link dropped with no surrounding context |
+
+**Scoring guide:**
+- 5: All links are descriptive, anchored, and contextual.
+- 3: Most links are good; occasional "click here" or bare URL.
+- 1: Majority of links are non-descriptive or bare URLs.
+
+---
+
+### 8. Formatting Signal Clarity — weight 5 %
+
+**Goal:** Formatting conveys semantic meaning, not decoration. LLMs must infer semantics from formatting.
+
+| Check | Pass condition | Violation examples |
+|---|---|---|
+| Bold marks UI elements or key terms only | `**…**` used for UI labels and introduced terms, not general emphasis | `**Note that** you must restart` (emphasis, not a UI label) |
+| Inline code marks exact identifiers | `` `…` `` used for code, file names, and system values — not regular words | `` `simply` `` or `` `important` `` styled as code for visual effect |
+| Callouts use a consistent pattern | Notes, warnings, tips use a consistent block format (`> **Note:**`) | Mixing `> Note:`, `**Note:**`, `NOTE:`, and plain paragraphs |
+| No all-caps for emphasis | Capitalized words used only for acronyms or proper names | `Do NOT run this command` — `NOT` in all-caps for stress |
+
+**Scoring guide:**
+- 5: Formatting is semantically consistent; a model can reliably infer meaning from marks.
+- 3: Occasional bold-for-emphasis or mixed callout styles.
+- 1: Formatting is used decoratively; semantic meaning cannot be inferred reliably.
+
+---
+
+## Output Format
+
+Return **only** a JSON block (no surrounding prose, no markdown fences outside the block):
+
+```json
+{
+  "file": "<relative or absolute path to the article>",
+  "overall_score": "<weighted average, 1 decimal place>",
+  "dimensions": {
+    "semantic_structure": {
+      "score": "<1-5>",
+      "rationale": "<≤ 2 sentences>",
+      "violations": ["<violation 1>", "..."]
+    },
+    "self_contained_sections": {
+      "score": "<1-5>",
+      "rationale": "<≤ 2 sentences>",
+      "violations": ["<violation 1>", "..."]
+    },
+    "terminology_consistency": {
+      "score": "<1-5>",
+      "rationale": "<≤ 2 sentences>",
+      "violations": ["<violation 1>", "..."]
+    },
+    "code_block_quality": {
+      "score": "<1-5>",
+      "rationale": "<≤ 2 sentences>",
+      "violations": ["<violation 1>", "..."]
+    },
+    "retrieval_metadata": {
+      "score": "<1-5>",
+      "rationale": "<≤ 2 sentences>",
+      "violations": ["<violation 1>", "..."]
+    },
+    "chunk_coherence": {
+      "score": "<1-5>",
+      "rationale": "<≤ 2 sentences>",
+      "violations": ["<violation 1>", "..."]
+    },
+    "reference_and_link_quality": {
+      "score": "<1-5>",
+      "rationale": "<≤ 2 sentences>",
+      "violations": ["<violation 1>", "..."]
+    },
+    "formatting_signal_clarity": {
+      "score": "<1-5>",
+      "rationale": "<≤ 2 sentences>",
+      "violations": ["<violation 1>", "..."]
+    }
+  }
+}
+```
+
+**Weights for overall_score computation:**
+
+| Dimension | Weight |
+|---|---|
+| semantic_structure | 0.20 |
+| self_contained_sections | 0.20 |
+| terminology_consistency | 0.15 |
+| code_block_quality | 0.15 |
+| retrieval_metadata | 0.10 |
+| chunk_coherence | 0.10 |
+| reference_and_link_quality | 0.05 |
+| formatting_signal_clarity | 0.05 |
+
+`overall_score = sum(score_i × weight_i)` — round to one decimal place.
+
+Do not output anything other than the JSON block.

--- a/.github/skills/llm-doc-optimization/SKILL.md
+++ b/.github/skills/llm-doc-optimization/SKILL.md
@@ -88,7 +88,7 @@ The rules below are designed to prevent those failure modes.
 
 | Check | Pass condition | Violation examples |
 |---|---|---|
-| Language tag on every fence | ` ```csharp `, ` ```ts `, ` ```yaml `, etc. | ` ``` ` with no language |
+| Language tag on every fence | ` ```C# `, ` ```ts `, ` ```yaml `, etc. | ` ``` ` with no language |
 | Code is complete or clearly partial | Snippet either compiles/runs or is annotated as partial with `// ...` | Unannounced mid-function snippet that omits necessary context |
 | Surrounding prose explains the code | At least one sentence before the block describes what it does | Code block dropped in with no introduction |
 | Identifiers match the prose | Variable/class names in code match the names discussed above the block | Prose says `UserService` but code uses `userSvc` without explanation |

--- a/.github/skills/seo-doc-optimization/SKILL.md
+++ b/.github/skills/seo-doc-optimization/SKILL.md
@@ -1,0 +1,368 @@
+---
+name: seo-doc-optimization
+description: "Scores a single markdown article against traditional and modern SEO best practices for Google Search ranking and content discoverability. Evaluates technical SEO (metadata, structure, linking) plus modern ranking factors (search intent, E-E-A-T signals, task completion, AI-era content quality). Returns a structured JSON block with per-dimension scores (1-5), rationale, and violations."
+argument-hint: "Path to the markdown article to score, e.g. C:\\docs\\articles\\overview.md"
+---
+
+# SEO Documentation Optimization Scoring
+
+You are an expert in technical documentation SEO and content discoverability. Evaluate the provided markdown article against the guidelines below and produce a structured JSON score.
+
+Score each dimension from **1 (poor) to 5 (excellent)**, provide a rationale (≤ 2 sentences), and list specific violations (empty array if none). Compute a weighted overall score at the end.
+
+---
+
+## Why SEO Readiness Matters for Documentation
+
+Documentation that ranks poorly in Google costs users time (they can't find answers) and costs support teams money (avoidable tickets). The most common causes are:
+
+- Generic or duplicate `title` / `description` metadata that search engines cannot distinguish
+- Missing primary keywords in the headings and first paragraph where crawlers weight them most
+- Thin content (too short, too abstract) that signals low value to ranking algorithms
+- Broken internal linking that prevents PageRank flow across the documentation site
+- Content structured for humans scrolling top-to-bottom rather than for featured-snippet extraction
+
+The rules below address each of those failure modes.
+
+---
+
+## Why Modern SEO Factors Determine Ranking
+
+Traditional SEO helps content get **indexed and understood** by search engines. However, Google's ranking algorithms have evolved significantly. Modern factors determine whether content actually **ranks or competes**:
+
+- **Intent-first ranking**: Google prioritizes content that matches what users actually want to accomplish, not just keyword matches. A page optimized for "Grid data binding" will lose to a page that clearly helps users bind data to a grid.
+- **E-E-A-T signals**: Experience, Expertise, Authoritativeness, and Trustworthiness are explicit ranking factors. Documentation must demonstrate real knowledge, not just restate API surfaces.
+- **Helpful Content System**: Google's algorithm demotes content that exists primarily for search engines rather than users. Content must demonstrably help users complete tasks.
+- **AI content detection**: Search engines increasingly identify and deprioritize generic, AI-generated content that lacks unique insights, real-world experience, or editorial voice.
+
+The scoring dimensions below cover both traditional technical SEO (dimensions 1–8) and modern ranking factors (dimensions 9–12).
+
+---
+
+## Scoring Dimensions
+
+### Part A: Technical SEO (Indexability & Understanding)
+
+### 1. Title and Meta Title Optimization — weight 15 %
+
+Source rules: front matter `title` and `meta_title` / `page_title` fields.
+
+| Check | Pass condition | Violation examples |
+|---|---|---|
+| `meta_title` / `page_title` is present | Field exists in front matter | Field is absent |
+| Primary keyword appears early in `meta_title` | The most specific term (component + feature + product) leads the value, e.g. `"Grid Data Binding - Kendo UI for jQuery"` | `"Kendo UI for jQuery - Grid Data Binding"` (product leads instead of topic) |
+| `meta_title` length is 40–70 characters | Within the range Google displays without truncation | 25 characters (too short) or 90 characters (truncated in SERPs) |
+| `title` (sidebar nav) is distinct and descriptive | Not a generic label shared by sibling articles | Multiple articles all titled `"Overview"` or `"Introduction"` without qualifier |
+| No keyword stuffing | Title reads naturally; keywords appear once, not repeated | `"Grid Grid DataGrid Kendo Grid Overview"` |
+
+**Scoring guide:**
+- 5: Keyword-leading `meta_title`, 40–70 chars, distinct across sibling articles.
+- 3: `meta_title` present but generic or slightly out of range.
+- 1: `meta_title` absent or a duplicate of other articles.
+
+---
+
+### 2. Meta Description Quality — weight 10 %
+
+Source rules: front matter `description` field.
+
+| Check | Pass condition | Violation examples |
+|---|---|---|
+| `description` is present | Field exists in front matter | Field is absent |
+| Length is 100–150 characters (hard limit — never exceed 150) | Fits Google's display window without truncation while providing sufficient context | 60 chars (too short, wastes SERP space) or 160 chars (exceeds the 150-character cap) |
+| Describes the specific outcome or task | Answers "what will the reader learn or accomplish?" | `"This article is about the Grid component"` — states subject, not value |
+| Contains the primary keyword naturally | Core term appears in the description without stuffing | Description never mentions the component or feature name |
+| Unique across sibling articles | No two articles share the same description | Two feature articles both say `"Configures the Grid component"` |
+| Includes an implicit call to action | Phrased to invite the click, e.g. "Learn how to…", "Discover…", "Find out…" | Flat declarative sentence with no engagement signal |
+
+**Scoring guide:**
+- 5: 120–155 chars, task-oriented, keyword-natural, unique, click-inviting.
+- 3: Present and unique but too short/long or purely declarative.
+- 1: Absent or a copy of another article's description.
+
+---
+
+### 3. Keyword Placement — weight 10 %
+
+| Check | Pass condition | Violation examples |
+|---|---|---|
+| Primary keyword in H1 | The article's main term appears in the single `#` heading | H1 is a generic label like `"Overview"` |
+| Primary keyword in the first paragraph | Core term used within the opening 50 words | Feature is first mentioned midway through the article |
+| Secondary keywords in H2 headings | Related terms and long-tail variants appear in `##` headings | All H2 headings are generic (`"Setup"`, `"Options"`, `"Example"`) without qualifying context |
+| Natural keyword density | Primary term appears several times in body text without forced repetition | Keyword appears once in 1500 words (too sparse) or 20 times in 500 words (stuffed) |
+| LSI / semantic terms present | Synonyms and closely related terms are used naturally in body text | Article about `"data binding"` never uses `"connect"`, `"fetch"`, `"source"`, `"remote data"` |
+
+**Scoring guide:**
+- 5: Keyword in H1 and opening paragraph; secondary keywords in H2s; natural density.
+- 3: Keyword in H1 but absent from first paragraph or H2 headings.
+- 1: H1 is generic; primary term rarely or never appears in the body.
+
+---
+
+### 4. Content Depth and Completeness — weight 10 %
+
+| Check | Pass condition | Violation examples |
+|---|---|---|
+| Minimum viable length | Article body is at least 300 words (thin content is a ranking signal) | 150-word stub with no examples |
+| Covers the topic end-to-end | Introduction, concept explanation, setup/usage, examples, and next steps are all present when relevant | Article jumps straight to code with no explanation of what the feature does |
+| Concrete examples | At least one code block or screenshot illustrates the key concept | Pure prose with no demonstrated usage |
+| Answers the implied user question | The title implies a question ("How to bind the Grid"); the article answers it directly | Title promises a how-to; article only describes the API surface without showing usage |
+| No excessive duplication with sibling articles | Unique value not replicated verbatim in other articles | Introduction paragraph copy-pasted across multiple articles |
+
+**Scoring guide:**
+- 5: ≥ 300 words, full coverage, concrete examples, unique value.
+- 3: Adequate length and examples but missing one major section.
+- 1: Thin, incomplete, or heavily duplicated.
+
+---
+
+### 5. Heading Structure for Featured Snippets — weight 8 %
+
+Google extracts featured snippets and `People Also Ask` answers from well-structured heading/content pairs.
+
+| Check | Pass condition | Violation examples |
+|---|---|---|
+| H2/H3 headings are question-like or task-like | Headings mirror common search queries, e.g. `"How to Enable Paging"`, `"What Is Virtual Scrolling"` | Generic headings: `"Paging"`, `"Scrolling"` |
+| Answer immediately follows the heading | The first sentence under a heading directly answers or defines the heading topic | Heading is followed by a lengthy preamble before the actual answer |
+| Lists and tables are used for enumerable facts | Step-by-step procedures use numbered lists; option sets use tables | Steps described as dense paragraphs |
+| Definition pattern for concept articles | Concept heading followed by a one-sentence definition (ideal for featured snippet extraction) | Concept introduced indirectly through examples only |
+| No heading-only sections | Every heading has at least one substantive paragraph or list beneath it | Heading followed immediately by another heading |
+
+**Scoring guide:**
+- 5: Headings are query-like; answers are immediate; lists/tables used correctly.
+- 3: Some headings are query-like; answers sometimes delayed.
+- 1: All headings are generic labels; no snippet-friendly structure.
+
+---
+
+### 6. Internal Linking — weight 7 %
+
+| Check | Pass condition | Violation examples |
+|---|---|---|
+| Contextual internal links present | The article links to related features, concepts, or prerequisites using meaningful anchor text | Article is self-contained with no outbound links |
+| Anchor text is descriptive | Link text describes the destination page, not just "here" or "this article" | `[click here](url)`, `[this page](url)` |
+| Links flow to deeper content | High-level articles link to detail articles (hub-and-spoke model) | Overview article has no links to feature-specific articles |
+| No orphan risk | Article is linked to from at least one other logical parent (implied; note if the article has no obvious parent heading) | Article exists with no navigation context (orphan page risk) |
+| Slug-based or stable URLs used | Internal links use `slug:` references or stable relative paths, not absolute URLs that may break | `https://docs.telerik.com/…` hardcoded instead of `slug:feature-name` |
+
+**Scoring guide:**
+- 5: Multiple contextual links with descriptive anchor text following the hub-and-spoke model.
+- 3: Some links present but anchor text is generic or links are sparse.
+- 1: No internal links; article is an island.
+
+---
+
+### 7. URL / Slug Quality — weight 5 %
+
+| Check | Pass condition | Violation examples |
+|---|---|---|
+| `slug` is present | Field exists in front matter | Field is absent |
+| Slug is descriptive and keyword-bearing | Slug reflects the article topic, e.g. `grid-remote-data-binding` | `article-123`, `page1`, `untitled` |
+| Slug uses lowercase and hyphens only | No uppercase, underscores, or spaces | `Grid_RemoteData`, `GridRemoteDataBinding` |
+| Slug length is reasonable | 3–6 words / 30–60 characters | Single-word slugs (`grid`) or very long slugs (`kendo-ui-for-jquery-grid-component-remote-data-binding-with-odata`) |
+| No keyword stuffing in slug | Each meaningful word appears once | `grid-grid-data-binding-grid` |
+
+**Scoring guide:**
+- 5: Descriptive, hyphenated, keyword-bearing slug of appropriate length.
+- 3: Slug is present but either generic or slightly too long/short.
+- 1: Slug absent, uses underscores/uppercase, or is a meaningless identifier.
+
+---
+
+### 8. Structured Data Readiness — weight 5 %
+
+Markdown content is often rendered by static-site generators or documentation platforms that can inject structured data. Evaluate whether the article content and front matter are structured to support this.
+
+| Check | Pass condition | Violation examples |
+|---|---|---|
+| `description` is a complete, standalone sentence | Can be used verbatim as the `description` in a JSON-LD `Article` object | Fragment: `"Grid data binding options."` |
+| Code examples are delimited with language tags | Enables platform to render `SoftwareSourceCode` structured data | Fenced blocks with no language |
+| Step-by-step procedures use numbered lists | Enables extraction as `HowTo` structured data | Procedures written as paragraphs |
+| FAQ-like sections use heading + answer pattern | Enables extraction as `FAQPage` structured data | Q&A embedded in prose with no distinguishing structure |
+| `title` matches H1 exactly (or differs only in casing) | Signals content coherence to crawlers | `title: "Overview"` but H1 is `"Grid Component Overview"` |
+
+**Scoring guide:**
+- 5: Description is a full sentence; code blocks labeled; steps numbered; title matches H1.
+- 3: Most checks pass but one or two structured-data signals are missing.
+- 1: Multiple missing signals; article is difficult to annotate with structured data.
+
+---
+
+### Part B: Modern SEO (Ranking & Competing)
+
+### 9. Search Intent Alignment — weight 10 %
+
+Google ranks content that matches what users actually want to accomplish, not just keyword matches. Identify the search intent behind the article's topic and evaluate whether the content delivers on that intent.
+
+| Check | Pass condition | Violation examples |
+|---|---|---|
+| Intent type is clear | Article structure matches the dominant intent: **informational** (explains a concept), **navigational** (helps find a specific thing), **transactional** (enables a task), or **commercial investigation** (compares options) | Article titled "How to Configure Paging" is structured as a reference (informational) instead of a how-to (transactional) |
+| Opening paragraph states the user goal | First 50 words acknowledge what the reader wants to accomplish | Article opens with component history or architecture instead of the user's goal |
+| Content format matches intent | How-to intents use step-by-step lists; comparison intents use tables; concept intents use definitions and diagrams | How-to article presents steps as prose paragraphs |
+| Question is answered early | The core answer or solution appears within the first screen (before scrolling) | Answer buried after extensive background or prerequisites |
+| Satisfies "People Also Ask" variants | Article addresses 2–3 related questions users commonly have about the topic | Narrow focus that ignores obvious follow-up questions like "What are the limitations?" or "How do I troubleshoot?" |
+| No intent mismatch in title vs. content | Title promise matches body delivery | Title says "Best Practices for…" but body only describes API options without opinionated guidance |
+
+**Scoring guide:**
+- 5: Intent type is explicit; opening states user goal; format matches intent; answer is early; related questions addressed.
+- 3: Intent is identifiable but format or depth doesn't fully match; answer is somewhat delayed.
+- 1: Intent mismatch between title and content; user goal never stated; format inappropriate for the task.
+
+---
+
+### 10. E-E-A-T Signals (Experience, Expertise, Authoritativeness, Trust) — weight 10 %
+
+Google's quality rater guidelines explicitly evaluate Experience, Expertise, Authoritativeness, and Trustworthiness. Technical documentation must demonstrate real knowledge.
+
+| Check | Pass condition | Violation examples |
+|---|---|---|
+| First-hand experience evident | Content includes details only someone who used the feature would know: edge cases, common mistakes, performance observations, version-specific behavior | Generic description that could be written from reading the API surface alone |
+| Explains "why", not just "how" | Rationale for recommendations is provided; trade-offs are discussed | "Set `pageSize` to 20" with no explanation of why 20 or when to use different values |
+| Acknowledges limitations or caveats | Known issues, unsupported scenarios, or performance constraints are mentioned when relevant | Feature presented as universally applicable with no caveats |
+| Accurate and up-to-date | Code examples work with current versions; deprecated approaches are flagged | Examples use outdated syntax or removed APIs without warning |
+| Authoritative voice | Confident, direct statements; avoids hedging language like "you might want to consider perhaps trying" | Excessive hedging that undermines trust |
+| Cites official sources when appropriate | Links to official API reference, release notes, or related documentation for claims that need verification | Asserts version requirements or breaking changes without linking to source |
+
+**Scoring guide:**
+- 5: Clear first-hand experience; explains why; acknowledges limitations; accurate; confident voice; sources cited.
+- 3: Technically accurate but lacks experience signals or rationale; some hedging.
+- 1: Generic content with no evidence of real usage; inaccurate or outdated; no limitations mentioned.
+
+---
+
+### 11. Task Completion & Usefulness — weight 5 %
+
+Google's Helpful Content System rewards content that helps users complete their actual task. Evaluate whether a reader could succeed using only this article.
+
+| Check | Pass condition | Violation examples |
+|---|---|---|
+| Self-contained for the core task | Reader can complete the primary task without mandatory external reading | Critical steps require visiting 3 other articles first |
+| Prerequisites are stated upfront | Required versions, packages, or prior setup are listed before the main content | Fails midway because of unstated dependency |
+| Working code examples | Code blocks are complete and runnable; not pseudo-code or fragments missing context | `// ... your code here ...` placeholders; imports omitted |
+| Expected outcome is shown | Screenshots, expected output, or success criteria are provided | Reader follows steps but has no way to verify success |
+| Troubleshooting common failures | At least one common error and its resolution are documented when applicable | Reader hits predictable error with no guidance |
+| Clear next steps | Article ends with logical follow-up actions or links to advanced topics | Abrupt ending with no forward path |
+
+**Scoring guide:**
+- 5: Self-contained; prerequisites stated; working examples; outcomes shown; troubleshooting included; clear next steps.
+- 3: Mostly complete but missing one key element (e.g., no troubleshooting or outcomes not shown).
+- 1: Incomplete examples; prerequisites missing; reader cannot succeed without significant external help.
+
+---
+
+### 12. AI-Era Content Quality — weight 5 %
+
+Search engines increasingly identify and deprioritize generic, AI-generated content. Documentation must demonstrate unique value that AI cannot easily replicate.
+
+| Check | Pass condition | Violation examples |
+|---|---|---|
+| Unique insights present | Contains observations, recommendations, or details not found in generic documentation | Restates what's already in the API reference with no added value |
+| Specific numbers and thresholds | Includes concrete values: performance benchmarks, recommended limits, version numbers | Vague guidance: "for better performance, use smaller page sizes" without specifics |
+| Real-world scenarios | Examples reflect actual use cases, not contrived demos | Example binds a grid to `["Item1", "Item2", "Item3"]` instead of realistic data |
+| Opinionated guidance | Takes a stance on best practices; recommends specific approaches | Lists all options without guidance on which to use when |
+| Editorial voice | Writing has personality, uses active voice, and reads as written by a human expert | Flat, robotic prose that could be template-generated |
+| No filler content | Every paragraph advances the reader's understanding; no padding | Lengthy introductions restating what the title already says; repetitive summaries |
+| Addresses "why this page exists" | Clear value proposition for why someone should read this instead of alternatives | Content is interchangeable with dozens of similar articles on the web |
+
+**Scoring guide:**
+- 5: Unique insights; specific numbers; real scenarios; opinionated; editorial voice; no filler; clear value.
+- 3: Some unique value but relies on generic patterns; lacks specificity or opinion in places.
+- 1: Generic, template-like content; no unique insights; could be AI-generated from API docs alone.
+
+---
+
+## Output Format
+
+Return **only** a JSON block (no surrounding prose, no markdown fences outside the block):
+
+```json
+{
+  "file": "<relative or absolute path to the article>",
+  "overall_score": "<weighted average, 1 decimal place>",
+  "dimensions": {
+    "title_and_meta_title": {
+      "score": "<1-5>",
+      "rationale": "<≤ 2 sentences>",
+      "violations": ["<violation 1>", "..."]
+    },
+    "meta_description_quality": {
+      "score": "<1-5>",
+      "rationale": "<≤ 2 sentences>",
+      "violations": ["<violation 1>", "..."]
+    },
+    "keyword_placement": {
+      "score": "<1-5>",
+      "rationale": "<≤ 2 sentences>",
+      "violations": ["<violation 1>", "..."]
+    },
+    "content_depth_and_completeness": {
+      "score": "<1-5>",
+      "rationale": "<≤ 2 sentences>",
+      "violations": ["<violation 1>", "..."]
+    },
+    "heading_structure_for_snippets": {
+      "score": "<1-5>",
+      "rationale": "<≤ 2 sentences>",
+      "violations": ["<violation 1>", "..."]
+    },
+    "internal_linking": {
+      "score": "<1-5>",
+      "rationale": "<≤ 2 sentences>",
+      "violations": ["<violation 1>", "..."]
+    },
+    "slug_quality": {
+      "score": "<1-5>",
+      "rationale": "<≤ 2 sentences>",
+      "violations": ["<violation 1>", "..."]
+    },
+    "structured_data_readiness": {
+      "score": "<1-5>",
+      "rationale": "<≤ 2 sentences>",
+      "violations": ["<violation 1>", "..."]
+    },
+    "search_intent_alignment": {
+      "score": "<1-5>",
+      "rationale": "<≤ 2 sentences>",
+      "violations": ["<violation 1>", "..."]
+    },
+    "eeat_signals": {
+      "score": "<1-5>",
+      "rationale": "<≤ 2 sentences>",
+      "violations": ["<violation 1>", "..."]
+    },
+    "task_completion_usefulness": {
+      "score": "<1-5>",
+      "rationale": "<≤ 2 sentences>",
+      "violations": ["<violation 1>", "..."]
+    },
+    "ai_era_content_quality": {
+      "score": "<1-5>",
+      "rationale": "<≤ 2 sentences>",
+      "violations": ["<violation 1>", "..."]
+    }
+  }
+}
+```
+
+**Weights for overall_score computation:**
+
+| Dimension | Weight | Category |
+|---|---|---|
+| title_and_meta_title | 0.15 | Technical SEO |
+| meta_description_quality | 0.10 | Technical SEO |
+| keyword_placement | 0.10 | Technical SEO |
+| content_depth_and_completeness | 0.10 | Technical SEO |
+| heading_structure_for_snippets | 0.08 | Technical SEO |
+| internal_linking | 0.07 | Technical SEO |
+| slug_quality | 0.05 | Technical SEO |
+| structured_data_readiness | 0.05 | Technical SEO |
+| search_intent_alignment | 0.10 | Modern SEO |
+| eeat_signals | 0.10 | Modern SEO |
+| task_completion_usefulness | 0.05 | Modern SEO |
+| ai_era_content_quality | 0.05 | Modern SEO |
+
+**Category subtotals:** Technical SEO = 70%, Modern SEO = 30%
+
+`overall_score = sum(score_i × weight_i)` — round to one decimal place.
+
+Do not output anything other than the JSON block.

--- a/.github/skills/seo-doc-optimization/SKILL.md
+++ b/.github/skills/seo-doc-optimization/SKILL.md
@@ -76,7 +76,7 @@ Source rules: front matter `description` field.
 | Includes an implicit call to action | Phrased to invite the click, e.g. "Learn how to…", "Discover…", "Find out…" | Flat declarative sentence with no engagement signal |
 
 **Scoring guide:**
-- 5: 120–155 chars, task-oriented, keyword-natural, unique, click-inviting.
+- 5: 120–150 chars, task-oriented, keyword-natural, unique, click-inviting.
 - 3: Present and unique but too short/long or purely declarative.
 - 1: Absent or a copy of another article's description.
 

--- a/.github/skills/style-guide-scoring/SKILL.md
+++ b/.github/skills/style-guide-scoring/SKILL.md
@@ -1,0 +1,245 @@
+---
+name: style-guide-scoring
+description: "Scores a single markdown article against the Progress DevTools Style Guide. Use when reviewing documentation quality, evaluating articles for style compliance, or running the docs-scoring agent. Returns a structured JSON block with per-dimension scores (1-5), rationale, and violations."
+argument-hint: "Path to the markdown article to score, e.g. C:\\docs\\articles\\overview.md"
+---
+
+# Style Guide Scoring
+
+You are an expert technical documentation reviewer. Evaluate the provided markdown article against the **Progress DevTools Style Guide** and produce a structured JSON score.
+
+## Source
+
+Use the scoring rules defined in this skill as the default source of truth. Do not read `C:\HelpMigration\tech-docs-style-guide` unless the prompt explicitly instructs you to consult that folder or a specific file in it.
+
+The full style guide lives at `C:\HelpMigration\tech-docs-style-guide` for optional deeper review only. When the prompt explicitly requires it, read only the specific source file or files needed for the requested check instead of scanning the whole folder.
+
+## Additional Guide Coverage
+
+Apply the following cross-cutting rules under the closest existing scoring dimension. Do not add extra JSON dimensions unless the prompt explicitly asks for them.
+
+Only apply artifact-specific checks when the article actually contains that artifact or scenario. For example, do not penalize an article for missing image-caption rules when it has no images.
+
+* Numbers (`numbers.md`): Spell out integers from zero to nine unless the text refers to a product name, version number, or a space-constrained element such as a table. Use digits for 10 and above. Use period-separated decimals (`10.6`). Use an en dash for ranges (`1&ndash;15`) with no spaces. Do not begin sentences, titles, headings, or captions with numerals.
+* Vocabulary and terminology (`vocabulary.md`, `brandnames.md`, `click-tap-select.md`, `personal-pronouns.md`): Prefer `checkbox`; use `click X` and `tap X`; use `hover over` as the verb and `hover` or `hovering` as the noun or adjective; prefer `unavailable` over `disabled` or `grayed out` for irrelevant UI state; use `earlier` and `later` for versions; use `starting with` instead of `since` or `as of` for version introductions; preserve official company, product, and third-party spelling; prefer gender-neutral pronouns or rewrite to avoid unnecessary gendering.
+* Programming language display names: In prose, headings, and code-block labels (tab headers, bold introductions), always write **C#** and **VB.NET**. Do not use alternative forms such as "csharp", "CSharp", "C Sharp", "vb", "VB", "Visual Basic", or "VB.Net". The fenced-code-block language tag must also follow this rule: use ` ```C# ` and ` ```VB.NET ` instead of ` ```csharp ` or ` ```vb `.
+* Links and cross-references (`cross-references.md`): Use descriptive anchor text that explains the destination or purpose. Vary repeated anchor text when citing the same resource often. Paraphrase internal documentation titles instead of quoting them exactly. Cite exact external resource titles and authors. When HTML syntax is available, prefer opening external links in a new tab.
+* Images, tables, and captions (`screenshots.md`, `tables-figures-code.md`): Require descriptive alt text for images. Captions, when used, should be bold, descriptive, in sentence case, and positioned before the element. Do not leave table cells blank; use `N/A`, `Not applicable`, or `None` when needed. Flag screenshots that expose sensitive data or visibly ignore default/light UI guidance.
+
+---
+
+## Scoring Dimensions
+
+Score each dimension from **1 (poor) to 5 (excellent)**. Provide a numeric score, a short rationale (≤ 2 sentences), and a list of specific violations found (empty array if none). At the end, compute an **overall score** as the weighted average (see weights below).
+
+When a rule from the "Additional Guide Coverage" section applies, score it under the closest existing dimension instead of inventing a new output field.
+
+### 1. Metadata & Front Matter — weight 15 %
+
+Source: `metadata.md`
+
+| Check | Pass condition |
+|---|---|
+| YAML front matter present | Article starts with `---` block |
+| `title` field | Present and non-empty |
+| `meta_title` or `page_title` | Present; ≤ 70 characters recommended |
+| `description` | Present; **must be 100–150 characters (hard limit — never exceed 150)** |
+| `slug` | Present and URL-safe (lowercase, hyphens only) |
+| Meta title quality | Front-loads the article topic/context; uses clear dash-separated parts when needed; includes component or product context when applicable |
+| Meta description quality | Accurate, specific, action-oriented, and non-templated; must be 100–150 characters with no exceptions; avoids filler and generic phrases |
+| Redirect metadata when applicable | `previous_url` is present when the article clearly represents moved, renamed, or redirected content |
+
+### 2. Titles and Headings — weight 15 %
+
+Source: `titles-and-headings.md`
+
+| Check | Pass condition |
+|---|---|
+| Single H1 | Exactly one `#` heading in the article |
+| Title case | Nouns, verbs, adjectives, adverbs, pronouns, subordinating conjunctions capitalized; coordinating conjunctions (`and`, `but`, `or`), articles (`a`, `an`, `the`), prepositions (`at`, `on`, `in`, …) lowercased unless first/last word |
+| Heading hierarchy | No skipped levels (e.g., H2 directly to H4) |
+| Parallel same-level headings | All siblings share the same grammatical form |
+| Subheading coverage | At least two subheadings per heading section (when content warrants) |
+| No trailing punctuation in headings | Headings do not end with `.`, `!`, or `?` (commas are allowed) |
+| Drop unnecessary articles | Articles are omitted where meaning stays clear |
+| No metaphors or API member names in conceptual headings | Headings describe the user goal; avoid metaphors and object types, methods, or events outside API-reference contexts |
+| Useful bridge text before subheadings | Content between a heading and its first subheading adds context instead of filler |
+| Avoid repeated parent wording in TOC-visible subheadings | Subheadings do not redundantly repeat the parent heading wording when the table of contents already provides that context |
+| Quote capitalization preserved | Quoted material keeps its original capitalization |
+| `-ing` forms used intentionally | `-ing` headings are acceptable for procedural/how-to topics, not as vague conceptual labels |
+| **No mixed verb forms across headings (high priority)** | All action headings in the article must use the same verb form — either gerund (`-ing`) or imperative/infinitive — consistently. Mixing forms such as "Installing the Package" alongside "Configure the Feed" in the same article is a violation. Choose one form and apply it to every action heading. |
+
+### 3. Tone and Voice — weight 15 %
+
+Source: `tone-and-voice.md`, `cheat-sheet.md`, `using-simple-non-ambiguous-language.md`, `personal-pronouns.md`
+
+| Check | Violation signal |
+|---|---|
+| No "simply", "it's easy", "it's that simple" | Any occurrence |
+| No "let's" (except getting-started guides) | Any occurrence outside getting-started context |
+| No "please note", "at this time" | Any occurrence |
+| No exclamation marks | Any `!` outside code blocks |
+| No gendered pronouns | Occurrences of "he/him/his/she/her/hers" used generically |
+| No jokes, pop-culture references, metaphors | Subjective; flag obvious cases |
+| No Latin abbreviations (e.g., i.e.) | `e.g.` or `i.e.` outside code blocks |
+| Friendly but professional register | Subjective; flag overly colloquial or overly formal passages |
+| No culture-specific references | Region-specific holidays, monetary units, phone/address formats, or similar local assumptions appear without necessity |
+| No slang, sarcasm, idioms, or emoticons | Any obvious occurrence |
+| Avoid vague subjective qualifiers | Terms such as "good", "best", or "worst" appear without objective support |
+| Inclusive pronoun usage | Prefer gender-neutral pronouns or sentence rewrites when pronouns are needed |
+
+### 4. Grammar and Language — weight 15 %
+
+Source: `basic-rules-and-guidelines.md`, `using-simple-non-ambiguous-language.md`, `contractions.md`, `numbers.md`, `vocabulary.md`
+
+| Check | Pass condition |
+|---|---|
+| American English spelling | No British-English variants (`behaviour`, `colour`, `organise`, `licence`, `centre`, `cancelled`) |
+| Active voice preference | Passive constructions (`was sent`, `is created`, etc.) kept to a minimum |
+| Sentence length | Sentences ≤ 25 words as a rule of thumb |
+| Paragraph length | 2–4 sentences, ≤ 6 lines |
+| No ambiguous contractions | Only safe contractions (`aren't`, `can't`, `don't`, `doesn't`, `haven't`, `didn't`, `shouldn't`, `couldn't`) used; disallowed forms (`you'll`, `it's` for "it has", `that's`, `there's`, `who's`, etc.) absent |
+| Imperative mood | Direct instructions use imperative mood, not gerund or passive |
+| Present simple preference | Uses present simple where possible; future, past, and perfect tenses appear only when needed for clarity |
+| Precise modality | Uses imperative, `must`, `need to`, or `have to` for obligation; avoids ambiguous `should`, `could`, and `would` where `can`, `will`, or direct instruction is clearer |
+| Avoid existential filler | Rephrases `there is` and `there are` when a stronger subject and verb are available |
+| Minimize gerunds in body text | Avoids unnecessary `-ing` forms, dangling `-ing` phrases, and `-ing` adjectives that obscure meaning |
+| Precise parts of speech | Uses nouns as nouns and verbs as verbs; avoids ambiguous conversions such as turning nouns into verbs |
+| Number style | Spells out zero through nine unless version/product/table context applies; uses digits for 10+; uses period-separated decimals; does not start sentences/headings/captions with numerals |
+
+### 5. Formatting Conventions — weight 15 %
+
+Source: `element-formatting.md`, `tables-figures-code.md`, `screenshots.md`
+
+| Check | Pass condition |
+|---|---|
+| UI elements in bold | Button names, menu items, tabs, dialog boxes wrapped in `**…**` |
+| Code elements in backticks | Class names, properties, events, methods, file names wrapped in `` `…` `` |
+| No bold for general emphasis | `**…**` not used for emphasis unrelated to UI element names |
+| Keyboard keys and shortcuts | Rendered in monospace with Initial Caps; combinations use `+` without spaces |
+| System resources in monospace | File paths, extensions, data types, tags, values, error messages, database names, and user input are wrapped in backticks |
+| Command-line formatting | Command references use monospace; command examples distinguish verbatim parts from variable placeholders where practical |
+| Commands not used as verbs | Avoids phrasing such as `` `cd` to the folder `` |
+| UI navigation paths | Menu or toolbar sequences use bold UI labels separated by `>` with spaces |
+| Captions and alt text when present | Images include meaningful alt text; captions are bold, descriptive, sentence case, and placed before the element |
+
+### 6. Lists — weight 10 %
+
+Source: `lists.md`
+
+| Check | Pass condition |
+|---|---|
+| Introductory sentence ends with colon | Every list is preceded by a sentence ending in `:` |
+| Items start with uppercase | First letter of each bullet/number capitalized |
+| Parallel structure | All items share the same grammatical form within a list |
+| Period consistency | Either all items end with `.` or none do (when at least one is a full sentence, all must end with `.`) |
+| Max nesting | No more than three levels of nesting |
+| No single-item lists | Avoid one-item lists unless justified |
+| Correct list type | Numbered lists describe sequences; bulleted lists describe equal-priority items |
+| No leading articles | Items avoid unnecessary opening articles such as "A" or "The" when they weaken scanability |
+| Repeated content factored into intro | Shared prefixes are moved into the introductory sentence instead of repeated in each item |
+| Action/context ordering | Steps state the action first, or begin with the needed context/condition when that improves clarity |
+| Definition list separator | Definition lists use `&mdash;` with no surrounding spaces; do not use a literal em dash character, a hyphen, or spaced dash forms; large definition lists may be better as tables |
+| Clarifications separated cleanly | Extra explanation appears in a second paragraph or aligned follow-up text, not as a run-on list item |
+
+### 7. Punctuation — weight 10 %
+
+Source: `punctuation.md`
+
+| Check | Pass condition |
+|---|---|
+| No space before punctuation | No ` .`, ` ,`, ` ?`, ` !`, ` :`, ` ;` |
+| Single space after punctuation | Only one space after `.`, `,`, `;`, `:`, `?`, `!` |
+| No space inside brackets | `( text )` is wrong; `(text)` is correct |
+| Hyphens/dashes not surrounded by spaces | `word - word` is wrong; `word&mdash;word` or `word-word` is correct |
+| No punctuation at end of headings | Headings do not end with `.`, `!`, `?` |
+| Bracket spacing and punctuation | Uses correct spaces before `(` and after `)`; punctuation placement inside/outside brackets matches sentence structure |
+| Serial comma in series | Uses the Oxford comma in series of three or more when needed for clarity |
+| "For example" and "that is" punctuation | Uses commas correctly around these phrases |
+| Range punctuation | Uses an en dash for numeric ranges; avoids hyphens and em dashes |
+
+### 8. Structure and Completeness — weight 5 %
+
+Source: `basic-rules-and-guidelines.md`, `cross-references.md`, `tables-figures-code.md`, `screenshots.md`
+
+| Check | Pass condition |
+|---|---|
+| Introductory paragraph | Article begins with 1–2 sentences describing the subject and its context |
+| See Also / Next Steps section | Article ends with a navigational section (optional but recommended) |
+| Short articles | No excessive scrolling required; single topic per article |
+| Topic introduction via subheadings | Each substantial new aspect is introduced with a subheading for readability and orientation |
+| Feature-focused scope | Prefers one feature/topic per article instead of mixing unrelated features |
+| Descriptive cross-references | Links explain the destination or purpose clearly; external references identify the resource precisely |
+| Media and table completeness when present | Figures/tables/screenshots include a caption or lead-in sentence when needed, table cells are not blank, and visible screenshots avoid sensitive/confidential data |
+
+---
+
+## Output Format
+
+Return **only** a JSON block (no surrounding prose, no markdown fences outside the block):
+
+```json
+{
+  "file": "<relative or absolute path to the article>",
+  "overall_score": "<weighted average, 1 decimal place>",
+  "dimensions": {
+    "metadata": {
+      "score": "<1-5>",
+      "rationale": "<≤ 2 sentences>",
+      "violations": ["<violation 1>", "..."]
+    },
+    "titles_and_headings": {
+      "score": "<1-5>",
+      "rationale": "<≤ 2 sentences>",
+      "violations": ["<violation 1>", "..."]
+    },
+    "tone_and_voice": {
+      "score": "<1-5>",
+      "rationale": "<≤ 2 sentences>",
+      "violations": ["<violation 1>", "..."]
+    },
+    "grammar_and_language": {
+      "score": "<1-5>",
+      "rationale": "<≤ 2 sentences>",
+      "violations": ["<violation 1>", "..."]
+    },
+    "formatting_conventions": {
+      "score": "<1-5>",
+      "rationale": "<≤ 2 sentences>",
+      "violations": ["<violation 1>", "..."]
+    },
+    "lists": {
+      "score": "<1-5>",
+      "rationale": "<≤ 2 sentences>",
+      "violations": ["<violation 1>", "..."]
+    },
+    "punctuation": {
+      "score": "<1-5>",
+      "rationale": "<≤ 2 sentences>",
+      "violations": ["<violation 1>", "..."]
+    },
+    "structure_and_completeness": {
+      "score": "<1-5>",
+      "rationale": "<≤ 2 sentences>",
+      "violations": ["<violation 1>", "..."]
+    }
+  }
+}
+```
+
+**Weights for overall_score computation:**
+
+| Dimension | Weight |
+|---|---|
+| metadata | 0.15 |
+| titles_and_headings | 0.15 |
+| tone_and_voice | 0.15 |
+| grammar_and_language | 0.15 |
+| formatting_conventions | 0.15 |
+| lists | 0.10 |
+| punctuation | 0.10 |
+| structure_and_completeness | 0.05 |
+
+`overall_score = sum(score_i × weight_i)` — round to one decimal place.
+
+Do not output anything other than the JSON block.


### PR DESCRIPTION
The purpose is to have automatic verification with each PR Copilot review for the main docs conventions

| Skill | Purpose |
|---|---|
| [accessibility-doc-optimization](.github/skills/accessibility-doc-optimization/SKILL.md) | Scores Markdown accessibility against WCAG-oriented practices, including headings, alt text, links, tables, plain language, formatting independence, callouts, and code blocks. |
| [llm-doc-optimization](.github/skills/llm-doc-optimization/SKILL.md) | Evaluates whether documentation is easy for LLMs and agents to retrieve, chunk, parse, and reason over. It checks structure, self-contained sections, terminology, code, metadata, links, and formatting. |
| [seo-doc-optimization](.github/skills/seo-doc-optimization/SKILL.md) | Scores traditional and modern SEO quality, covering metadata, keywords, content depth, links, slugs, structured data, search intent, E-E-A-T, task completion, and AI-era content quality. |
| [style-guide-scoring](.github/skills/style-guide-scoring/SKILL.md) | Provides the broadest review against the Progress DevTools Style Guide, including metadata, headings, tone, grammar, formatting, lists, punctuation, and article completeness. |